### PR TITLE
Get fire alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ terraform/.terraform/*
 *.tfplan
 .coverage
 coverage.xml
+
+*.tsv
+*.geojson

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,4 @@ terraform/.terraform/*
 .coverage
 coverage.xml
 
-*.tsv
-*.geojson
+tests/mocked_environment_tests/*.tsv

--- a/datapump_utils/fire_alerts.py
+++ b/datapump_utils/fire_alerts.py
@@ -5,53 +5,92 @@ import os
 from datapump_utils.util import get_date_string
 from datapump_utils.s3 import s3_client
 
-ACTIVE_FIRE_ALERTS_24HR_CSV_URLS = {
-    "MODIS": "https://firms.modaps.eosdis.nasa.gov/data/active_fire/c6/csv/MODIS_C6_Global_24h.csv",
-    "VIIRS": "https://firms.modaps.eosdis.nasa.gov/data/active_fire/viirs/csv/VNP14IMGTDL_NRT_Global_24h.csv",
+ACTIVE_FIRE_ALERTS_48HR_CSV_URLS = {
+    "MODIS": "https://firms.modaps.eosdis.nasa.gov/data/active_fire/c6/csv/MODIS_C6_Global_48h.csv",
+    "VIIRS": "https://firms.modaps.eosdis.nasa.gov/data/active_fire/viirs/csv/VNP14IMGTDL_NRT_Global_48h.csv",
 }
 DATA_LAKE_BUCKET = os.environ["S3_BUCKET_DATA_LAKE"]
-PIPELINE_BUCKET = os.environ["S3_BUCKET_PIPELINE"]
+BRIGHTNESS_FIELDS = {
+    "MODIS": ["brightness", "bright_t31"],
+    "VIIRS": ["bright_ti4", "bright_ti5"],
+}
+VERSIONS = {"MODIS": "v6", "VIIRS": "v1"}
 
 
 def process_active_fire_alerts(alert_type):
-    response = requests.get(ACTIVE_FIRE_ALERTS_24HR_CSV_URLS[alert_type])
+    response = requests.get(ACTIVE_FIRE_ALERTS_48HR_CSV_URLS[alert_type])
 
     if response.status_code != 200:
         raise Exception(
             f"Unable to get active {alert_type} fire alerts, FIRMS returned status code {response.status_code}"
         )
 
-    csv_reader = csv.DictReader(response.text.splitlines(), delimiter=",")
+    lines = response.text.splitlines()
+    csv_reader = csv.DictReader(lines, delimiter=",")
+    sorted_rows = sorted(
+        csv_reader, key=lambda row: f"{row['acq_date']}_{row['acq_time']}"
+    )
+
+    last_row = sorted_rows[-1]
+
     fields = [
         "latitude",
         "longitude",
         "acq_date",
+        "acq_time",
         "confidence",
-        "brightness",
-        "bright_ti4",
-        "bright_t31",
-        "bright_ti5",
-        "frp",
     ]
-    result_name = f"{alert_type}_{get_date_string()}"
+    fields += BRIGHTNESS_FIELDS[alert_type]
+    fields.append("frp")
+
+    result_name = f"fire_alerts_{alert_type.lower()}"
 
     tsv_file = open(f"{result_name}.tsv", "w", newline="")
     tsv_writer = csv.DictWriter(tsv_file, fieldnames=fields, delimiter="\t")
     tsv_writer.writeheader()
 
-    for row in csv_reader:
-        tsv_row = dict()
-        for field in fields:
-            if field in row:
-                tsv_row[field] = row[field]
+    nrt_s3_directory = f"nasa_{alert_type.lower()}_fire_alerts/{VERSIONS[alert_type]}/vector/espg-4326/nrt"
+    last_saved_date, last_saved_min = _get_last_saved_alert_time(nrt_s3_directory)
 
-        tsv_writer.writerow(tsv_row)
+    first_row = None
+    for row in sorted_rows:
+        # only start once we confirm we're past the overlap with the last dataset
+        if row["acq_date"] >= last_saved_date and row["acq_time"] > last_saved_min:
+            if not first_row:
+                first_row = row
+
+            _write_row(row, fields, tsv_writer)
 
     tsv_file.close()
 
     # upload both files to s3
+    file_name = f"{first_row['acq_date']}-{first_row['acq_time']}_{last_row['acq_date']}-{last_row['acq_time']}.tsv"
     with open(f"{result_name}.tsv", "rb") as tsv_result:
-        pipeline_key = (
-            f"{alert_type}_active_fire_alerts/vector/espg-4326/tsv/{result_name}.tsv"
+        pipeline_key = f"{nrt_s3_directory}/{file_name}"
+        s3_client().upload_fileobj(
+            tsv_result, Bucket=DATA_LAKE_BUCKET, Key=pipeline_key
         )
-        s3_client().upload_fileobj(tsv_result, Bucket=PIPELINE_BUCKET, Key=pipeline_key)
+
+
+def _get_last_saved_alert_time(nrt_s3_directory):
+    response = s3_client().list_objects(
+        Bucket=DATA_LAKE_BUCKET, Prefix=nrt_s3_directory
+    )
+
+    if "Contents" in response:
+        last_file = response["Contents"][-1]
+        last_min = last_file["Key"][-8:-4]
+        last_date = last_file["Key"][-19:-9]
+
+        return last_date, last_min
+    else:
+        return "0000-00-00", "0000"
+
+
+def _write_row(row, fields, writer):
+    tsv_row = dict()
+    for field in fields:
+        if field in row:
+            tsv_row[field] = row[field]
+
+    writer.writerow(tsv_row)

--- a/datapump_utils/fire_alerts.py
+++ b/datapump_utils/fire_alerts.py
@@ -49,7 +49,7 @@ def process_active_fire_alerts(alert_type):
     tsv_writer = csv.DictWriter(tsv_file, fieldnames=fields, delimiter="\t")
     tsv_writer.writeheader()
 
-    nrt_s3_directory = f"nasa_{alert_type.lower()}_fire_alerts/{VERSIONS[alert_type]}/vector/epsg-4326/near_real_time"
+    nrt_s3_directory = f"nasa_{alert_type.lower()}_fire_alerts/{VERSIONS[alert_type]}/vector/epsg-4326/tsv/near_real_time"
     last_saved_date, last_saved_min = _get_last_saved_alert_time(nrt_s3_directory)
 
     first_row = None

--- a/datapump_utils/fire_alerts.py
+++ b/datapump_utils/fire_alerts.py
@@ -49,7 +49,7 @@ def process_active_fire_alerts(alert_type):
     tsv_writer = csv.DictWriter(tsv_file, fieldnames=fields, delimiter="\t")
     tsv_writer.writeheader()
 
-    nrt_s3_directory = f"nasa_{alert_type.lower()}_fire_alerts/{VERSIONS[alert_type]}/vector/epsg-4326/nrt"
+    nrt_s3_directory = f"nasa_{alert_type.lower()}_fire_alerts/{VERSIONS[alert_type]}/vector/epsg-4326/near_real_time"
     last_saved_date, last_saved_min = _get_last_saved_alert_time(nrt_s3_directory)
 
     first_row = None

--- a/datapump_utils/fire_alerts.py
+++ b/datapump_utils/fire_alerts.py
@@ -49,7 +49,7 @@ def process_active_fire_alerts(alert_type):
     tsv_writer = csv.DictWriter(tsv_file, fieldnames=fields, delimiter="\t")
     tsv_writer.writeheader()
 
-    nrt_s3_directory = f"nasa_{alert_type.lower()}_fire_alerts/{VERSIONS[alert_type]}/vector/espg-4326/nrt"
+    nrt_s3_directory = f"nasa_{alert_type.lower()}_fire_alerts/{VERSIONS[alert_type]}/vector/epsg-4326/nrt"
     last_saved_date, last_saved_min = _get_last_saved_alert_time(nrt_s3_directory)
 
     first_row = None

--- a/datapump_utils/fire_alerts.py
+++ b/datapump_utils/fire_alerts.py
@@ -1,0 +1,56 @@
+from geojson import Feature, FeatureCollection, Point
+import requests
+import csv
+import os
+
+from datapump_utils.util import get_date_string
+from datapump_utils.s3 import s3_client
+
+ACTIVE_FIRE_ALERTS_24HR_CSV_URLS = {
+    "MODIS": "https://firms.modaps.eosdis.nasa.gov/data/active_fire/c6/csv/MODIS_C6_Global_24h.csv",
+    "VIIRS": "https://firms.modaps.eosdis.nasa.gov/data/active_fire/viirs/csv/VNP14IMGTDL_NRT_Global_24h.csv",
+}
+DATA_LAKE_BUCKET = os.environ["S3_BUCKET_DATA_LAKE"]
+
+
+def process_active_fire_alerts(alert_type):
+    response = requests.get(ACTIVE_FIRE_ALERTS_24HR_CSV_URLS[alert_type])
+    csv_reader = csv.DictReader(response.text.splitlines(), delimiter=",")
+
+    result_name = f"{alert_type}_{get_date_string()}"
+    key = f"{alert_type}_active_fire_alerts/vector/espg-4326/{result_name}"
+
+    tsv_file = open(f"{result_name}.tsv", "w", newline="")
+    tsv_writer = csv.DictWriter(
+        tsv_file, fieldnames=csv_reader.fieldnames, delimiter="\t"
+    )
+    tsv_writer.writeheader()
+
+    features = []
+    for row in csv_reader:
+        # write lat, lon to tsv file
+        tsv_writer.writerow(row)
+
+        # add to in-memory geojson
+        geom = Point((float(row["longitude"]), float(row["latitude"])))
+        del row["latitude"]
+        del row["longitude"]
+
+        features.append(Feature(geometry=geom, properties=row))
+
+    tsv_file.close()
+
+    collection = FeatureCollection(features)
+    with open(f"{result_name}.geojson", "w") as geojson:
+        geojson.write("%s" % collection)
+
+    # upload both files to s3
+    with open(f"{result_name}.tsv", "rb") as tsv_result:
+        s3_client().upload_fileobj(
+            tsv_result, Bucket=DATA_LAKE_BUCKET, Key=f"{key}.tsv"
+        )
+
+    with open(f"{result_name}.geojson", "rb") as geojson_result:
+        s3_client().upload_fileobj(
+            geojson_result, Bucket=DATA_LAKE_BUCKET, Key=f"{key}.geojson"
+        )

--- a/datapump_utils/fire_alerts.py
+++ b/datapump_utils/fire_alerts.py
@@ -16,6 +16,12 @@ PIPELINE_BUCKET = os.environ["S3_BUCKET_PIPELINE"]
 
 def process_active_fire_alerts(alert_type):
     response = requests.get(ACTIVE_FIRE_ALERTS_24HR_CSV_URLS[alert_type])
+
+    if response.status_code != 200:
+        raise Exception(
+            f"Unable to get active {alert_type} fire alerts, FIRMS returned status code {response.status_code}"
+        )
+
     csv_reader = csv.DictReader(response.text.splitlines(), delimiter=",")
 
     result_name = f"{alert_type}_{get_date_string()}"

--- a/datapump_utils/util.py
+++ b/datapump_utils/util.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import date
 import os
 
 from datapump_utils.logger import get_logger
@@ -12,8 +12,7 @@ else:
 
 
 def get_date_string():
-    today = datetime.datetime.today()
-    return "{}{}{}".format(today.year, today.month, today.day)
+    return date.today().strftime("%Y-%m-%d")
 
 
 def secret_suffix() -> str:

--- a/lambdas/get_latest_fire_alerts/src/lambda_function.py
+++ b/lambdas/get_latest_fire_alerts/src/lambda_function.py
@@ -1,0 +1,6 @@
+from datapump_utils.fire_alerts import process_active_fire_alerts
+
+
+def handler(event, context):
+    process_active_fire_alerts("MODIS")
+    process_active_fire_alerts("VIIRS")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ requests-mock~=1.7.0
 # lambdas
 PyYAML~=5.2
 shapely~=1.6.4.post2
+geojson~=2.5.0
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,9 @@ setup(
     license="MIT",
     # only list requirements for datapump_utils here
     # place requirements of lambda functions into requirement-dev.txt
-    install_requires=["boto3~=1.10.7", "requests~=2.22.0",],  # noqa: E231
+    install_requires=[
+        "boto3~=1.10.7",
+        "requests~=2.22.0",
+        "geojson~=2.5.0",
+    ],  # noqa: E231
 )

--- a/terraform/archive.tf
+++ b/terraform/archive.tf
@@ -33,3 +33,9 @@ data "archive_file" "lambda_check_new_glad_alerts" {
   source_dir  = "../lambdas/check_new_glad_alerts/src"
   output_path = "../lambdas/check_new_glad_alerts/lambda.zip"
 }
+
+data "archive_file" "lambda_get_latest_fire_alerts" {
+  type        = "zip"
+  source_dir  = "../lambdas/get_latest_fire_alerts/src"
+  output_path = "../lambdas/get_latest_fire_alerts/lambda.zip"
+}

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -27,3 +27,11 @@ resource "aws_cloudwatch_event_target" "nightly-new-glad-alerts-check" {
   role_arn  = aws_iam_role.datapump_states.arn
   count     = var.environment == "production" || var.environment == "staging" ? 1 : 0
 }
+
+resource "aws_cloudwatch_event_target" "nightly-fire-alerts" {
+  rule      = aws_cloudwatch_event_rule.everyday-11-pm-est.name
+  target_id = substr("${local.project}-nightly-fire-alerts${local.name_suffix}", 0, 64)
+  arn       = aws_lambda_function.get_latest_fire_alerts.arn
+  role_arn  = aws_iam_role.datapump_lambda.arn
+  count     = var.environment == "production" || var.environment == "staging" ? 1 : 0
+}

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -111,7 +111,27 @@ resource "aws_lambda_function" "check_new_glad_alerts" {
   filename         = data.archive_file.lambda_check_new_glad_alerts.output_path
   source_code_hash = data.archive_file.lambda_check_new_glad_alerts.output_base64sha256
   role             = aws_iam_role.datapump_lambda.arn
-  runtime          = var.lambda_check_new_glad_alerts_runtime
+  runtime          = var.lambda_get_latest_fire_alerts_runtime
+  handler          = "lambda_function.handler"
+  memory_size      = var.lambda_get_latest_fire_alerts_memory_size
+  timeout          = var.lambda_get_latest_fire_alerts_timeout
+  publish          = true
+  tags             = local.tags
+  layers           = [module.lambda_layers.datapump_utils_arn]
+  environment {
+    variables = {
+      ENV                   = var.environment
+      S3_BUCKET_DATA_LAKE   = data.terraform_remote_state.core.outputs.data-lake_bucket
+    }
+  }
+}
+
+resource "aws_lambda_function" "get_latest_fire_alerts" {
+  function_name    = substr("${local.project}-get_latest_fire_alerts${local.name_suffix}",0, 64)
+  filename         = data.archive_file.lambda_get_latest_fire_alerts.output_path
+  source_code_hash = data.archive_file.lambda_get_latest_fire_alerts.output_base64sha256
+  role             = aws_iam_role.datapump_lambda.arn
+  runtime          = var.lambda_get_latest_fire_alerts_runtime
   handler          = "lambda_function.handler"
   memory_size      = var.lambda_check_new_glad_alerts_memory_size
   timeout          = var.lambda_check_new_glad_alerts_timeout

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -120,8 +120,10 @@ resource "aws_lambda_function" "check_new_glad_alerts" {
   layers           = [module.lambda_layers.datapump_utils_arn]
   environment {
     variables = {
-      ENV                   = var.environment
-      S3_BUCKET_DATA_LAKE   = data.terraform_remote_state.core.outputs.data-lake_bucket
+      ENV                = var.environment
+      S3_BUCKET_PIPELINE = data.terraform_remote_state.core.outputs.pipelines_bucket
+      DATASETS       = jsonencode(var.datasets)
+      GLAD_ALERTS_PATH   = "s3://gfw2-data/forest_change/umd_landsat_alerts/prod/analysis"
     }
   }
 }
@@ -140,10 +142,9 @@ resource "aws_lambda_function" "get_latest_fire_alerts" {
   layers           = [module.lambda_layers.datapump_utils_arn]
   environment {
     variables = {
-      ENV                = var.environment
-      S3_BUCKET_PIPELINE = data.terraform_remote_state.core.outputs.pipelines_bucket
-      DATASETS       = jsonencode(var.datasets)
-      GLAD_ALERTS_PATH   = "s3://gfw2-data/forest_change/umd_landsat_alerts/prod/analysis"
+      ENV                 = var.environment
+      S3_BUCKET_PIPELINE  = data.terraform_remote_state.core.outputs.pipelines_bucket
+      S3_BUCKET_DATA_LAKE = data.terraform_remote_state.core.outputs.data-lake_bucket
     }
   }
 }

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -143,7 +143,6 @@ resource "aws_lambda_function" "get_latest_fire_alerts" {
   environment {
     variables = {
       ENV                 = var.environment
-      S3_BUCKET_PIPELINE  = data.terraform_remote_state.core.outputs.pipelines_bucket
       S3_BUCKET_DATA_LAKE = data.terraform_remote_state.core.outputs.data-lake_bucket
     }
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -33,6 +33,11 @@ variable "lambda_update_new_aoi_statuses_runtime" {
   description = "Runtime version for AWS Lambda"
 }
 
+variable "lambda_get_latest_fire_alerts_runtime" {
+  type        = string
+  description = "Runtime version for AWS Lambda"
+}
+
 variable "lambda_submit_job_memory_size" {
   type        = number
   description = "Memory limit in MB for AWS Lambda function"
@@ -63,6 +68,12 @@ variable "lambda_update_new_aoi_statuses_memory_size" {
   description = "Memory limit in MB for AWS Lambda function"
 }
 
+variable "lambda_get_latest_fire_alerts_memory_size" {
+  type        = number
+  description = "Memory limit in MB for AWS Lambda function"
+}
+
+
 variable "lambda_submit_job_timeout" {
   type        = number
   description = "Timeout in sec for AWS Lambda function"
@@ -89,6 +100,11 @@ variable "lambda_check_new_glad_alerts_timeout" {
 }
 
 variable "lambda_update_new_aoi_statuses_timeout" {
+  type        = number
+  description = "Timeout in sec for AWS Lambda function"
+}
+
+variable "lambda_get_latest_fire_alerts_timeout" {
   type        = number
   description = "Timeout in sec for AWS Lambda function"
 }

--- a/terraform/vars/gfw-datapump-dev.tfvars
+++ b/terraform/vars/gfw-datapump-dev.tfvars
@@ -24,6 +24,10 @@ lambda_check_new_glad_alerts_runtime     = "python3.7"
 lambda_check_new_glad_alerts_memory_size = 1024
 lambda_check_new_glad_alerts_timeout     = 300
 
+lambda_get_latest_fire_alerts_runtime     = "python3.7"
+lambda_get_latest_fire_alerts_memory_size = 1024
+lambda_get_latest_fire_alerts_timeout     = 300
+
 geotrellis_jar = "s3://gfw-pipelines-staging/geotrellis/jars/treecoverloss-assembly-1.0.0.jar"
 
 datasets = {

--- a/terraform/vars/gfw-datapump-production.tfvars
+++ b/terraform/vars/gfw-datapump-production.tfvars
@@ -24,4 +24,8 @@ lambda_check_new_glad_alerts_runtime     = "python3.7"
 lambda_check_new_glad_alerts_memory_size = 1024
 lambda_check_new_glad_alerts_timeout     = 300
 
+lambda_get_latest_fire_alerts_runtime     = "python3.7"
+lambda_get_latest_fire_alerts_memory_size = 1024
+lambda_get_latest_fire_alerts_timeout     = 300
+
 geotrellis_jar = "s3://gfw-pipelines-staging/geotrellis/jars/treecoverloss-assembly-1.0.0.jar"

--- a/terraform/vars/gfw-datapump-staging.tfvars
+++ b/terraform/vars/gfw-datapump-staging.tfvars
@@ -24,6 +24,10 @@ lambda_check_new_glad_alerts_runtime     = "python3.7"
 lambda_check_new_glad_alerts_memory_size = 1024
 lambda_check_new_glad_alerts_timeout     = 300
 
+lambda_get_latest_fire_alerts_runtime     = "python3.7"
+lambda_get_latest_fire_alerts_memory_size = 1024
+lambda_get_latest_fire_alerts_timeout     = 300
+
 geotrellis_jar = "s3://gfw-pipelines-staging/geotrellis/jars/treecoverloss-assembly-1.0.0.jar"
 
 datasets = {

--- a/tests/mock_environment/mock_environment.py
+++ b/tests/mock_environment/mock_environment.py
@@ -187,6 +187,22 @@ def _mock_s3_setup():
         Key=f"{glad_alerts_prefix}/tile2.tif",
     )
 
+    s3_client().upload_fileobj(
+        open(
+            os.path.join(CURDIR, "mock_files/2020-01-21-0010_2020-01-21-0028.tsv"), "r"
+        ),
+        Bucket=os.environ["S3_BUCKET_DATA_LAKE"],
+        Key=f"nasa_modis_fire_alerts/v6/vector/espg-4326/nrt/2020-01-20-0030_2020-01-20-0040.tsv",
+    )
+
+    s3_client().upload_fileobj(
+        open(
+            os.path.join(CURDIR, "mock_files/2020-01-21-0010_2020-01-21-0028.tsv"), "r"
+        ),
+        Bucket=os.environ["S3_BUCKET_DATA_LAKE"],
+        Key=f"nasa_modis_fire_alerts/v6/vector/espg-4326/nrt/2020-01-21-0010_2020-01-21-0028.tsv",
+    )
+
 
 def _mock_secrets():
     client = boto3.client("secretsmanager", region_name="us-east-1")

--- a/tests/mock_environment/mock_environment.py
+++ b/tests/mock_environment/mock_environment.py
@@ -53,6 +53,7 @@ os.environ["PUBLIC_SUBNET_IDS"] = json.dumps(["test_subnet", "test_subnet"])
 os.environ["EC2_KEY_NAME"] = "test_ec2_key_name"
 os.environ["EMR_INSTANCE_PROFILE"] = "TEST_EMR_INSTANCE_PROFILE"
 os.environ["EMR_SERVICE_ROLE"] = "TEST_SERVICE_ROLE"
+os.environ["S3_BUCKET_DATA_LAKE"] = "test_datalake_bucket"
 
 
 def mock_environment():
@@ -68,6 +69,8 @@ def mock_environment():
 def _mock_s3_setup():
     pipeline_bucket = f"gfw-pipelines{bucket_suffix()}"
     s3_client().create_bucket(Bucket=pipeline_bucket)
+    s3_client().create_bucket(Bucket=os.environ["S3_BUCKET_DATA_LAKE"])
+
     with open(os.path.join(CURDIR, "mock_files/test1.jar"), "r") as test1_jar:
         s3_client().upload_fileobj(
             test1_jar, Bucket=pipeline_bucket, Key="geotrellis/jars/test1.jar"

--- a/tests/mock_environment/mock_environment.py
+++ b/tests/mock_environment/mock_environment.py
@@ -192,7 +192,7 @@ def _mock_s3_setup():
             os.path.join(CURDIR, "mock_files/2020-01-21-0010_2020-01-21-0028.tsv"), "r"
         ),
         Bucket=os.environ["S3_BUCKET_DATA_LAKE"],
-        Key=f"nasa_modis_fire_alerts/v6/vector/epsg-4326/near_real_time/2020-01-20-0030_2020-01-20-0040.tsv",
+        Key=f"nasa_modis_fire_alerts/v6/vector/epsg-4326/tsv/near_real_time/2020-01-20-0030_2020-01-20-0040.tsv",
     )
 
     s3_client().upload_fileobj(
@@ -200,7 +200,7 @@ def _mock_s3_setup():
             os.path.join(CURDIR, "mock_files/2020-01-21-0010_2020-01-21-0028.tsv"), "r"
         ),
         Bucket=os.environ["S3_BUCKET_DATA_LAKE"],
-        Key=f"nasa_modis_fire_alerts/v6/vector/epsg-4326/near_real_time/2020-01-21-0010_2020-01-21-0028.tsv",
+        Key=f"nasa_modis_fire_alerts/v6/vector/epsg-4326/tsv/near_real_time/2020-01-21-0010_2020-01-21-0028.tsv",
     )
 
 

--- a/tests/mock_environment/mock_environment.py
+++ b/tests/mock_environment/mock_environment.py
@@ -192,7 +192,7 @@ def _mock_s3_setup():
             os.path.join(CURDIR, "mock_files/2020-01-21-0010_2020-01-21-0028.tsv"), "r"
         ),
         Bucket=os.environ["S3_BUCKET_DATA_LAKE"],
-        Key=f"nasa_modis_fire_alerts/v6/vector/espg-4326/nrt/2020-01-20-0030_2020-01-20-0040.tsv",
+        Key=f"nasa_modis_fire_alerts/v6/vector/epsg-4326/nrt/2020-01-20-0030_2020-01-20-0040.tsv",
     )
 
     s3_client().upload_fileobj(
@@ -200,7 +200,7 @@ def _mock_s3_setup():
             os.path.join(CURDIR, "mock_files/2020-01-21-0010_2020-01-21-0028.tsv"), "r"
         ),
         Bucket=os.environ["S3_BUCKET_DATA_LAKE"],
-        Key=f"nasa_modis_fire_alerts/v6/vector/espg-4326/nrt/2020-01-21-0010_2020-01-21-0028.tsv",
+        Key=f"nasa_modis_fire_alerts/v6/vector/epsg-4326/nrt/2020-01-21-0010_2020-01-21-0028.tsv",
     )
 
 

--- a/tests/mock_environment/mock_environment.py
+++ b/tests/mock_environment/mock_environment.py
@@ -192,7 +192,7 @@ def _mock_s3_setup():
             os.path.join(CURDIR, "mock_files/2020-01-21-0010_2020-01-21-0028.tsv"), "r"
         ),
         Bucket=os.environ["S3_BUCKET_DATA_LAKE"],
-        Key=f"nasa_modis_fire_alerts/v6/vector/epsg-4326/nrt/2020-01-20-0030_2020-01-20-0040.tsv",
+        Key=f"nasa_modis_fire_alerts/v6/vector/epsg-4326/near_real_time/2020-01-20-0030_2020-01-20-0040.tsv",
     )
 
     s3_client().upload_fileobj(
@@ -200,7 +200,7 @@ def _mock_s3_setup():
             os.path.join(CURDIR, "mock_files/2020-01-21-0010_2020-01-21-0028.tsv"), "r"
         ),
         Bucket=os.environ["S3_BUCKET_DATA_LAKE"],
-        Key=f"nasa_modis_fire_alerts/v6/vector/epsg-4326/nrt/2020-01-21-0010_2020-01-21-0028.tsv",
+        Key=f"nasa_modis_fire_alerts/v6/vector/epsg-4326/near_real_time/2020-01-21-0010_2020-01-21-0028.tsv",
     )
 
 

--- a/tests/mocked_environment_tests/test_get_active_fire_alerts.py
+++ b/tests/mocked_environment_tests/test_get_active_fire_alerts.py
@@ -1,0 +1,116 @@
+import csv
+import geojson
+import pytest
+from moto import mock_s3, mock_secretsmanager
+
+from tests.mock_environment.mock_environment import mock_environment
+
+from datapump_utils.util import get_date_string
+from datapump_utils.s3 import s3_client
+from datapump_utils.fire_alerts import (
+    process_active_fire_alerts,
+    ACTIVE_FIRE_ALERTS_24HR_CSV_URLS,
+)
+
+
+@mock_secretsmanager
+@mock_s3
+@pytest.mark.parametrize("alert_type", ["MODIS", "VIIRS"])
+def test_get_active_fire_alerts(alert_type, requests_mock):
+    mock_environment()
+
+    test_response = TEST_FIRE_ALERT_RESPONSE[alert_type]
+    requests_mock.get(
+        url=ACTIVE_FIRE_ALERTS_24HR_CSV_URLS[alert_type], text=test_response
+    )
+
+    process_active_fire_alerts(alert_type)
+    result_name = f"{alert_type}_{get_date_string()}"
+    with open(f"{result_name}.tsv", "r") as tsv_result_file:
+        with open(f"{result_name}.geojson", "r") as geojson_result_file:
+            tsv_result = csv.DictReader(
+                tsv_result_file.read().splitlines(), delimiter="\t"
+            )
+            expected_result = csv.DictReader(test_response.splitlines(), delimiter=",")
+            geojson_result = geojson.load(geojson_result_file)
+
+            for result_row, expected_row, feature in zip(
+                tsv_result, expected_result, geojson_result.features
+            ):
+                assert result_row["latitude"] == expected_row["latitude"]
+                assert result_row["longitude"] == expected_row["longitude"]
+
+                assert feature.geometry.coordinates[0] == float(
+                    expected_row["longitude"]
+                )
+                assert feature.geometry.coordinates[1] == float(
+                    expected_row["latitude"]
+                )
+
+    assert s3_client().head_object(
+        Bucket="test_datalake_bucket",
+        Key=f"{alert_type}_active_fire_alerts/vector/espg-4326/{result_name}.tsv",
+    )
+    assert s3_client().head_object(
+        Bucket="test_datalake_bucket",
+        Key=f"{alert_type}_active_fire_alerts/vector/espg-4326/{result_name}.geojson",
+    )
+
+
+TEST_FIRE_ALERT_RESPONSE = {
+    "MODIS": """latitude,longitude,brightness,scan,track,acq_date,acq_time,satellite,confidence,version,bright_t31,frp,daynight
+-27.402,147.909,331.4,1.1,1.1,2020-01-21,0030,T,53,6.0NRT,315,11.4,D
+-27.412,147.907,340.4,1.1,1.1,2020-01-21,0030,T,83,6.0NRT,316.7,26.6,D
+-27.413,147.918,337.6,1.1,1.1,2020-01-21,0030,T,79,6.0NRT,316.7,21.9,D
+-27.415,147.93,331.7,1.1,1.1,2020-01-21,0030,T,67,6.0NRT,316.2,11.9,D
+-28.234,149.859,335,1.4,1.2,2020-01-21,0030,T,81,6.0NRT,315.9,23.7,D
+-28.238,149.853,331,1.4,1.2,2020-01-21,0030,T,75,6.0NRT,315.4,15.8,D
+-30.807,151.412,322.6,1.9,1.4,2020-01-21,0030,T,65,6.0NRT,303.5,29.7,D
+-30.809,151.432,329.9,2,1.4,2020-01-21,0030,T,78,6.0NRT,302.9,53,D
+-30.362,146.945,343.9,1.1,1,2020-01-21,0030,T,87,6.0NRT,313.6,36.4,D
+-30.364,146.956,337.5,1.1,1,2020-01-21,0030,T,80,6.0NRT,313.5,24.1,D
+-33.006,146.297,326.6,1.1,1,2020-01-21,0030,T,24,6.0NRT,310.2,8.6,D
+-33.016,146.296,337.1,1.1,1,2020-01-21,0030,T,83,6.0NRT,311,24.6,D
+-33.886,142.684,341.6,1,1,2020-01-21,0030,T,87,6.0NRT,313.3,27.1,D
+-33.888,142.695,354.6,1,1,2020-01-21,0030,T,96,6.0NRT,314.2,55.2,D
+-33.889,142.706,357.8,1,1,2020-01-21,0030,T,98,6.0NRT,314.5,64.6,D
+-37.692,145.032,317.4,1.1,1,2020-01-21,0030,T,59,6.0NRT,299.8,7.7,D
+-37.696,145.025,313.6,1.1,1,2020-01-21,0030,T,46,6.0NRT,299,5.8,D
+-10.025,147.827,318.9,1.1,1,2020-01-21,0025,T,49,6.0NRT,297.1,7.6,D
+-10.026,147.837,319.5,1.1,1,2020-01-21,0025,T,46,6.0NRT,297.4,8,D
+-19.029,146.633,312.5,1,1,2020-01-21,0025,T,27,6.0NRT,294.5,6,D
+-19.469,145.6,331.6,1.1,1,2020-01-21,0025,T,75,6.0NRT,302.4,13.9,D
+-19.471,145.61,340.8,1.1,1,2020-01-21,0025,T,86,6.0NRT,302,30.8,D
+-19.475,145.603,333.9,1.1,1,2020-01-21,0025,T,79,6.0NRT,301.1,18,D
+-19.477,145.613,330.3,1.1,1,2020-01-21,0025,T,71,6.0NRT,300.3,13.7,D
+-19.351,144.597,326.5,1.2,1.1,2020-01-21,0025,T,50,6.0NRT,302.3,10.9,D
+-23.623,148.66,335.3,1.1,1,2020-01-21,0025,T,86,6.0NRT,297.2,27.1,D
+-23.625,148.671,333.3,1.1,1,2020-01-21,0025,T,84,6.0NRT,298.4,23.3,D
+-25.647,150.53,327.4,1.5,1.2,2020-01-21,0025,T,70,6.0NRT,302.5,21.3,D
+-26.062,147.095,345.1,1,1,2020-01-21,0025,T,88,6.0NRT,317.8,28.9,D
+-26.095,146.798,337.9,1,1,2020-01-21,0025,T,79,6.0NRT,318.2,18.9,D
+""",
+    "VIIRS": """latitude,longitude,bright_ti4,scan,track,acq_date,acq_time,satellite,confidence,version,bright_ti5,frp,daynight
+65.76917,24.18936,338.9,0.43,0.38,2020-01-22,0036,N,nominal,1.0NRT,272,6,N
+65.76575,24.18696,312.4,0.43,0.38,2020-01-22,0036,N,nominal,1.0NRT,269.3,6,N
+65.76232,24.18457,329.4,0.43,0.38,2020-01-22,0036,N,nominal,1.0NRT,270.5,5.8,N
+65.56535,22.21959,307.7,0.47,0.4,2020-01-22,0042,N,nominal,1.0NRT,269.2,2.3,N
+65.55402,22.25519,330,0.47,0.39,2020-01-22,0042,N,nominal,1.0NRT,269.9,5.5,N
+56.40143,41.33034,295.7,0.37,0.58,2020-01-22,0042,N,nominal,1.0NRT,270.3,0.6,N
+59.2752,27.88592,301.7,0.4,0.37,2020-01-22,0042,N,nominal,1.0NRT,271.6,0.8,N
+60.80533,1.44585,314.4,0.58,0.7,2020-01-22,0042,N,nominal,1.0NRT,275.7,2.6,N
+60.13363,15.42122,303.5,0.39,0.44,2020-01-22,0042,N,nominal,1.0NRT,271.2,0.8,N
+58.35916,12.37974,298.2,0.47,0.48,2020-01-22,0042,N,nominal,1.0NRT,274.1,0.6,N
+58.08508,11.82646,355.6,0.49,0.49,2020-01-22,0042,N,nominal,1.0NRT,276.3,11.4,N
+58.08558,11.8179,304.4,0.49,0.49,2020-01-22,0042,N,nominal,1.0NRT,274.6,6.1,N
+57.06064,9.97395,302.2,0.56,0.52,2020-01-22,0042,N,nominal,1.0NRT,268.1,1.9,N
+57.0619,9.97555,305.9,0.56,0.52,2020-01-22,0042,N,nominal,1.0NRT,269.1,1.6,N
+53.57033,-0.59705,322.3,0.71,0.75,2020-01-22,0042,N,nominal,1.0NRT,275.2,3.3,N
+53.397,-1.3877,319.5,0.76,0.77,2020-01-22,0042,N,nominal,1.0NRT,273.8,2.9,N
+53.39651,-1.39242,321.2,0.76,0.77,2020-01-22,0042,N,nominal,1.0NRT,274.2,4.1,N
+51.1042,18.9431,301.6,0.39,0.36,2020-01-22,0042,N,nominal,1.0NRT,272.3,1.6,N
+49.88803,24.74233,323.2,0.45,0.39,2020-01-22,0042,N,nominal,1.0NRT,269.9,3,N
+49.88648,24.74154,326.6,0.45,0.39,2020-01-22,0042,N,nominal,1.0NRT,269.7,2.6,N
+49.8877,24.73541,297.4,0.45,0.39,2020-01-22,0042,N,nominal,1.0NRT,269.6,0.7,N
+51.17791,16.11321,340.7,0.45,0.39,2020-01-22,0042,N,nominal,1.0NRT,273.8,10.3,N""",
+}

--- a/tests/mocked_environment_tests/test_get_active_fire_alerts.py
+++ b/tests/mocked_environment_tests/test_get_active_fire_alerts.py
@@ -35,7 +35,7 @@ def test_get_active_fire_alerts(alert_type, requests_mock):
 
     assert s3_client().head_object(
         Bucket=os.environ["S3_BUCKET_DATA_LAKE"],
-        Key=f"nasa_{alert_type.lower()}_fire_alerts/{VERSIONS[alert_type]}/vector/epsg-4326/near_real_time/{TEST_S3_NAMES[alert_type]}.tsv",
+        Key=f"nasa_{alert_type.lower()}_fire_alerts/{VERSIONS[alert_type]}/vector/epsg-4326/tsv/near_real_time/{TEST_S3_NAMES[alert_type]}.tsv",
     )
 
 

--- a/tests/mocked_environment_tests/test_get_active_fire_alerts.py
+++ b/tests/mocked_environment_tests/test_get_active_fire_alerts.py
@@ -35,7 +35,7 @@ def test_get_active_fire_alerts(alert_type, requests_mock):
 
     assert s3_client().head_object(
         Bucket=os.environ["S3_BUCKET_DATA_LAKE"],
-        Key=f"nasa_{alert_type.lower()}_fire_alerts/{VERSIONS[alert_type]}/vector/espg-4326/nrt/{TEST_S3_NAMES[alert_type]}.tsv",
+        Key=f"nasa_{alert_type.lower()}_fire_alerts/{VERSIONS[alert_type]}/vector/epsg-4326/nrt/{TEST_S3_NAMES[alert_type]}.tsv",
     )
 
 

--- a/tests/mocked_environment_tests/test_get_active_fire_alerts.py
+++ b/tests/mocked_environment_tests/test_get_active_fire_alerts.py
@@ -35,7 +35,7 @@ def test_get_active_fire_alerts(alert_type, requests_mock):
 
     assert s3_client().head_object(
         Bucket=os.environ["S3_BUCKET_DATA_LAKE"],
-        Key=f"nasa_{alert_type.lower()}_fire_alerts/{VERSIONS[alert_type]}/vector/epsg-4326/nrt/{TEST_S3_NAMES[alert_type]}.tsv",
+        Key=f"nasa_{alert_type.lower()}_fire_alerts/{VERSIONS[alert_type]}/vector/epsg-4326/near_real_time/{TEST_S3_NAMES[alert_type]}.tsv",
     )
 
 

--- a/tests/mocked_environment_tests/test_get_active_fire_alerts.py
+++ b/tests/mocked_environment_tests/test_get_active_fire_alerts.py
@@ -1,6 +1,7 @@
 import csv
 import geojson
 import pytest
+import os
 from moto import mock_s3, mock_secretsmanager
 
 from tests.mock_environment.mock_environment import mock_environment
@@ -48,11 +49,11 @@ def test_get_active_fire_alerts(alert_type, requests_mock):
                 )
 
     assert s3_client().head_object(
-        Bucket="test_datalake_bucket",
-        Key=f"{alert_type}_active_fire_alerts/vector/espg-4326/{result_name}.tsv",
+        Bucket=os.environ["S3_BUCKET_PIPELINE"],
+        Key=f"features/{alert_type}_active_fire_alerts/{result_name}.tsv",
     )
     assert s3_client().head_object(
-        Bucket="test_datalake_bucket",
+        Bucket=os.environ["S3_BUCKET_DATA_LAKE"],
         Key=f"{alert_type}_active_fire_alerts/vector/espg-4326/{result_name}.geojson",
     )
 


### PR DESCRIPTION
Get VIIRS and MODIS alerts daily and save as a geojson to the datalake and as a TSV to the pipeline bucket.

@thomas-maschler, a few things to confirm:

- Data lake path. E.g. for modis I used modis_active_fire_alerts/vector/espg-4326/MODIS_2020-01-23.geojson. Does this seem alright to you?
- For TSV, I'm just converting CSV to TSV and keeping all the fields, since I imagine we might want to keep them in the final dataset. Does this make sense as an input to GeoTrellis for what you were thinking? Also, does GeoTrellis require some kind of ID field? The current download scripts generates one out of the lat/lon/time combination for the gdb.