### PR TITLE
Allow multiple datasets to be updated simultaneously

### DIFF
--- a/datapump_utils/summary_analysis.py
+++ b/datapump_utils/summary_analysis.py
@@ -232,17 +232,18 @@ def get_dataset_result_paths(
 
     for analysis, ds_ids in datasets.items():
         ds_keys = get_dataset_result_keys(ds_ids)
-        for key_path, ds_id in ds_keys:
-            if (
-                feature_type != "gadm"
-            ):  # TODO temp solution, need to deal with gadm output being different
-                dataset_result_paths[
-                    ds_id
-                ] = f"{analysis_result_paths[analysis]}/{feature_type}/{key_path}"
-            else:
-                dataset_result_paths[
-                    ds_id
-                ] = f"{analysis_result_paths[analysis]}/{key_path}"
+        for key_path, ds_ids in ds_keys:
+            for ds_id in ds_ids:
+                if (
+                    feature_type != "gadm"
+                ):  # TODO temp solution, need to deal with gadm output being different
+                    dataset_result_paths[
+                        ds_id
+                    ] = f"{analysis_result_paths[analysis]}/{feature_type}/{key_path}"
+                else:
+                    dataset_result_paths[
+                        ds_id
+                    ] = f"{analysis_result_paths[analysis]}/{key_path}"
 
     return dataset_result_paths
 

--- a/terraform/vars/terraform-dev.tfvars
+++ b/terraform/vars/terraform-dev.tfvars
@@ -35,63 +35,63 @@ geotrellis_jar = "s3://gfw-pipelines-dev/geotrellis/jars/treecoverloss-assembly-
 datasets = {
   "geostore": {
     "annualupdate_minimal": {
-      "change" = "952f3a90-ea03-4bf7-93a7-5ffbca48248d"
-      "summary" = "8a857b48-971d-4358-bd91-243d248ec713"
-      "whitelist" = "2508ebe7-ee26-4ddd-aeb1-d7e6d2772ccb"
+      "change" = ["952f3a90-ea03-4bf7-93a7-5ffbca48248d"]
+      "summary" = ["8a857b48-971d-4358-bd91-243d248ec713"]
+      "whitelist" = ["2508ebe7-ee26-4ddd-aeb1-d7e6d2772ccb"]
     }
     "gladalerts": {
-      "daily_alerts" = "23483d57-4bf7-426a-903b-b917a335eec0"
-      "weekly_alerts" = "3172b978-3ef1-4e01-8943-03a4c259f12f"
-      "summary" = "489a5e5d-067f-4528-9395-a20c86ed329e"
-      "whitelist" = "cc0a64f1-a656-42f0-9383-7f1b68b4e46b"
+      "daily_alerts" = ["23483d57-4bf7-426a-903b-b917a335eec0"]
+      "weekly_alerts" = ["3172b978-3ef1-4e01-8943-03a4c259f12f"]
+      "summary" = ["489a5e5d-067f-4528-9395-a20c86ed329e"]
+      "whitelist" = ["cc0a64f1-a656-42f0-9383-7f1b68b4e46b"]
     }
   }
   "gadm": {
     "gladalerts": {
       "iso": {
-        "weekly_alerts" = "f79d86c8-e1f7-4611-8172-5ab029c45c8d"
+        "weekly_alerts" = ["f79d86c8-e1f7-4611-8172-5ab029c45c8d"]
       }
       "adm1": {
-        "weekly_alerts" = "2c192cfd-52d2-440b-85c1-4496b7cf3de7"
+        "weekly_alerts" = ["2c192cfd-52d2-440b-85c1-4496b7cf3de7"]
       }
       "adm2": {
-        "daily_alerts" = "f328893b-1a53-4d11-b00a-e6f5767db1be"
-        "weekly_alerts" = "a6195a49-7d58-4284-af29-24dc7ddd627f"
+        "daily_alerts" = ["f328893b-1a53-4d11-b00a-e6f5767db1be"]
+        "weekly_alerts" = ["a6195a49-7d58-4284-af29-24dc7ddd627f"]
       }
     },
     "firealerts": {
       "viirs": {
-        "all" = "003539d8-b713-4df2-9e31-5eda80353191"
+        "all" = ["003539d8-b713-4df2-9e31-5eda80353191"]
         "iso": {
-          "weekly_alerts" = "3775de0b-eefc-4325-ae4f-27ef7e04a6f1"
+          "weekly_alerts" = ["3775de0b-eefc-4325-ae4f-27ef7e04a6f1"]
         }
         "adm1": {
-          "weekly_alerts" = "0b9ab27d-4003-4a89-87ca-69d34642fc4a"
+          "weekly_alerts" = ["0b9ab27d-4003-4a89-87ca-69d34642fc4a"]
         }
         "adm2": {
-          "daily_alerts" = "17388a14-b28e-4b76-bad7-2d174b9f143d"
-          "weekly_alerts" = "6562ac9b-516d-49ce-ab21-191d1e5fec93"
+          "daily_alerts" = ["17388a14-b28e-4b76-bad7-2d174b9f143d"]
+          "weekly_alerts" = ["6562ac9b-516d-49ce-ab21-191d1e5fec93"]
         }
       }
       "modis": {
-        "all" = "2861d8b5-6abf-4602-81d0-1311cafce0fc"
+        "all" = ["2861d8b5-6abf-4602-81d0-1311cafce0fc"]
         "iso": {
-          "weekly_alerts" = "be3bdf28-a969-4312-a9e3-3ea517908a2a"
+          "weekly_alerts" = ["be3bdf28-a969-4312-a9e3-3ea517908a2a"]
         }
         "adm1": {
-          "weekly_alerts" = "832df160-13ab-42b8-9409-38cc3128db4c"
+          "weekly_alerts" = ["832df160-13ab-42b8-9409-38cc3128db4c"]
         }
         "adm2": {
-          "daily_alerts" = "b80c6564-ed47-44b4-8baf-b1831441bcb7"
-          "weekly_alerts" = "ab047d27-1ff1-4a7e-a1f2-1a165d5e0a4b"
+          "daily_alerts" = ["b80c6564-ed47-44b4-8baf-b1831441bcb7"]
+          "weekly_alerts" = ["ab047d27-1ff1-4a7e-a1f2-1a165d5e0a4b"]
         }
       }
     }
   }
   "wdpa": {
     "gladalerts": {
-      "daily_alerts" = "99b1e1ea-eea8-4212-9868-ee4b69f1b268",
-      "weekly_alerts" = "7e0669c2-e35b-4fa4-9e06-7a3c8e0cd767"
+      "daily_alerts" = ["99b1e1ea-eea8-4212-9868-ee4b69f1b268"],
+      "weekly_alerts" = ["7e0669c2-e35b-4fa4-9e06-7a3c8e0cd767"]
     }
   }
 }

--- a/terraform/vars/terraform-production.tfvars
+++ b/terraform/vars/terraform-production.tfvars
@@ -35,78 +35,78 @@ geotrellis_jar = "s3://gfw-pipelines/geotrellis/jars/treecoverloss-assembly-1.1.
 datasets = {
   "geostore": {
     "annualupdate_minimal": {
-      "change" = "ecb4817b-a09e-4c78-b735-617e93a7ff4c"
-      "summary" = "b2603f43-8349-4401-99d3-2fb56f889388"
-      "whitelist" = "28006d70-42b5-4034-9008-505806101863"
+      "change" = ["ecb4817b-a09e-4c78-b735-617e93a7ff4c"]
+      "summary" = ["b2603f43-8349-4401-99d3-2fb56f889388"]
+      "whitelist" = ["28006d70-42b5-4034-9008-505806101863"]
     }
     "gladalerts": {
-      "daily_alerts" = "bd35ab8e-1810-4eda-981e-5f0e6fe76f74"
-      "weekly_alerts" = "95735f8d-b86b-485a-8766-c480dd4da21d"
-      "summary" = "11454c79-e0ac-4c58-90ee-dcc9d9d30031"
-      "whitelist" = "61d9f9bc-883c-4c70-865a-af8126c7ccee"
+      "daily_alerts" = ["bd35ab8e-1810-4eda-981e-5f0e6fe76f74"]
+      "weekly_alerts" = ["95735f8d-b86b-485a-8766-c480dd4da21d"]
+      "summary" = ["11454c79-e0ac-4c58-90ee-dcc9d9d30031"]
+      "whitelist" = ["61d9f9bc-883c-4c70-865a-af8126c7ccee"]
     }
     "firealerts_modis": {
-      "daily_alerts" = "b7bf28ef-e893-47da-844a-25a46115fe34"
-      "weekly_alerts" = "1f7bb181-7b28-4823-8aa5-28335268f961"
-      "whitelist" = "d7d9a4b0-e295-42a8-bd46-fb48981c1eca"
+      "daily_alerts" = ["b7bf28ef-e893-47da-844a-25a46115fe34"]
+      "weekly_alerts" = ["1f7bb181-7b28-4823-8aa5-28335268f961"]
+      "whitelist" = ["d7d9a4b0-e295-42a8-bd46-fb48981c1eca"]
     }
     "firealerts_viirs": {
-      "daily_alerts" = "825edfcd-07f4-4b2b-9054-282663c60caa"
-      "weekly_alerts" = "cfd880fd-8b81-46c2-b3e3-84ba22955337"
-      "whitelist" = "e101f15a-4104-4dfd-bade-164986154694"
+      "daily_alerts" = ["825edfcd-07f4-4b2b-9054-282663c60caa"]
+      "weekly_alerts" = ["cfd880fd-8b81-46c2-b3e3-84ba22955337"]
+      "whitelist" = ["e101f15a-4104-4dfd-bade-164986154694"]
     }
   }
   "gadm": {
     "gladalerts": {
       "iso": {
-        "weekly_alerts" = "2c444b8d-991a-4e90-bb18-6d9063be1432"
+        "weekly_alerts" = ["2c444b8d-991a-4e90-bb18-6d9063be1432"]
       }
       "adm1": {
-        "weekly_alerts" = "094ae08c-3bf2-4d85-830e-e6d4cbc5c05d"
+        "weekly_alerts" = ["094ae08c-3bf2-4d85-830e-e6d4cbc5c05d"]
       }
       "adm2": {
-        "daily_alerts" = "2cacc2dc-35d6-46ab-8641-384267b8ba64",
-        "weekly_alerts" = "6476cd26-446a-4bc0-add5-79baeecceb12"
+        "daily_alerts" = ["2cacc2dc-35d6-46ab-8641-384267b8ba64"]
+        "weekly_alerts" = ["6476cd26-446a-4bc0-add5-79baeecceb12"]
       }
     }
     "firealerts_viirs": {
-      "all" = "76642243-d895-48f7-b8e8-5333851bd00f"
+      "all" = ["76642243-d895-48f7-b8e8-5333851bd00f"]
       "iso": {
-        "weekly_alerts" = "4625ce33-4046-49e3-9861-86d9b1832710"
+        "weekly_alerts" = ["4625ce33-4046-49e3-9861-86d9b1832710"]
       }
       "adm1": {
-        "weekly_alerts" = "0759c142-3a10-445e-a0f8-7e2c61c23344"
+        "weekly_alerts" = ["0759c142-3a10-445e-a0f8-7e2c61c23344"]
       }
       "adm2": {
-        "daily_alerts" = "c1bb5e10-4da9-4776-8362-ab48a746fcb5"
-        "weekly_alerts" = "13b5df89-abdd-4235-9cd0-accd1c38f11a"
+        "daily_alerts" = ["c1bb5e10-4da9-4776-8362-ab48a746fcb5"]
+        "weekly_alerts" = ["13b5df89-abdd-4235-9cd0-accd1c38f11a"]
       }
     }
     "firealerts_modis": {
       "iso": {
-        "weekly_alerts" = "9801eea9-6cbc-4d93-9845-de6fa267fbae"
+        "weekly_alerts" = ["9801eea9-6cbc-4d93-9845-de6fa267fbae"]
       }
       "adm1": {
-        "weekly_alerts" = "29aec1f5-7f76-4b44-bd4b-61fb803765ee"
+        "weekly_alerts" = ["29aec1f5-7f76-4b44-bd4b-61fb803765ee"]
       }
       "adm2": {
-        "daily_alerts" = "269af948-fc1c-40d7-823b-35bdb75c67ad"
-        "weekly_alerts" = "724293e5-8eac-4b7e-b7fb-e190db2633a0"
+        "daily_alerts" = ["269af948-fc1c-40d7-823b-35bdb75c67ad"]
+        "weekly_alerts" = ["724293e5-8eac-4b7e-b7fb-e190db2633a0"]
       }
     }
   }
   "wdpa": {
     "gladalerts": {
-      "daily_alerts" = "bfb86d53-c8de-46c5-a424-94eb63fea6da",
-      "weekly_alerts" = "8b7240e7-8372-4b6e-9aed-4694c7a46b49"
+      "daily_alerts" = ["bfb86d53-c8de-46c5-a424-94eb63fea6da"]
+      "weekly_alerts" = ["8b7240e7-8372-4b6e-9aed-4694c7a46b49"]
     }
     "firealerts_modis": {
-      "daily_alerts" = "46aa211a-f1e7-491c-af26-1dfcf1e88c91"
-      "weekly_alerts" = "30575408-697b-4151-b430-d54462b54cc9"
+      "daily_alerts" = ["46aa211a-f1e7-491c-af26-1dfcf1e88c91"]
+      "weekly_alerts" = ["30575408-697b-4151-b430-d54462b54cc9"]
     }
     "firealerts_viirs": {
-      "daily_alerts" = "a8575b2f-5035-4855-85e8-a16255aed666"
-      "weekly_alerts" = "eeb586f8-0ea7-4f76-a5b3-2e5bc8cabcbf"
+      "daily_alerts" = ["a8575b2f-5035-4855-85e8-a16255aed666"]
+      "weekly_alerts" = ["eeb586f8-0ea7-4f76-a5b3-2e5bc8cabcbf"]
     }
   }
 }

--- a/terraform/vars/terraform-staging.tfvars
+++ b/terraform/vars/terraform-staging.tfvars
@@ -35,78 +35,78 @@ geotrellis_jar = "s3://gfw-pipelines-staging/geotrellis/jars/treecoverloss-assem
 datasets = {
   "geostore": {
     "annualupdate_minimal": {
-      "change" = "952f3a90-ea03-4bf7-93a7-5ffbca48248d"
-      "summary" = "8a857b48-971d-4358-bd91-243d248ec713"
-      "whitelist" = "2508ebe7-ee26-4ddd-aeb1-d7e6d2772ccb"
+      "change" = ["952f3a90-ea03-4bf7-93a7-5ffbca48248d"]
+      "summary" = ["8a857b48-971d-4358-bd91-243d248ec713"]
+      "whitelist" = ["2508ebe7-ee26-4ddd-aeb1-d7e6d2772ccb"]
     }
     "gladalerts": {
-      "daily_alerts" = "23483d57-4bf7-426a-903b-b917a335eec0"
-      "weekly_alerts" = "3172b978-3ef1-4e01-8943-03a4c259f12f"
-      "summary" = "489a5e5d-067f-4528-9395-a20c86ed329e"
-      "whitelist" = "cc0a64f1-a656-42f0-9383-7f1b68b4e46b"
+      "daily_alerts" = ["23483d57-4bf7-426a-903b-b917a335eec0"]
+      "weekly_alerts" = ["3172b978-3ef1-4e01-8943-03a4c259f12f"]
+      "summary" = ["489a5e5d-067f-4528-9395-a20c86ed329e"]
+      "whitelist" = ["cc0a64f1-a656-42f0-9383-7f1b68b4e46b"]
     }
     "firealerts_modis": {
-      "daily_alerts" = "c0254765-e921-45e5-9eed-72b7294ce150"
-      "weekly_alerts" = "5586eb14-8016-4630-8e2b-7636a0b26983"
-      "whitelist" = "fab92867-45f0-4e47-af4e-73ea6b9372e3"
+      "daily_alerts" = ["c0254765-e921-45e5-9eed-72b7294ce150"]
+      "weekly_alerts" = ["5586eb14-8016-4630-8e2b-7636a0b26983"]
+      "whitelist" = ["fab92867-45f0-4e47-af4e-73ea6b9372e3"]
     }
     "firealerts_viirs": {
-      "daily_alerts" = "5d7305db-e074-4e33-b011-c34dc09709ba"
-      "weekly_alerts" = "290fa76b-d954-4473-bef2-b7e89f778436"
-      "whitelist" = "4e0cd805-2339-41ce-af02-8ab093ce7ebc"
+      "daily_alerts" = ["5d7305db-e074-4e33-b011-c34dc09709ba"]
+      "weekly_alerts" = ["290fa76b-d954-4473-bef2-b7e89f778436"]
+      "whitelist" = ["4e0cd805-2339-41ce-af02-8ab093ce7ebc"]
     }
   }
   "gadm": {
     "gladalerts": {
       "iso": {
-        "weekly_alerts" = "f79d86c8-e1f7-4611-8172-5ab029c45c8d"
+        "weekly_alerts" = ["f79d86c8-e1f7-4611-8172-5ab029c45c8d"]
       }
       "adm1": {
-        "weekly_alerts" = "2c192cfd-52d2-440b-85c1-4496b7cf3de7"
+        "weekly_alerts" = ["2c192cfd-52d2-440b-85c1-4496b7cf3de7"]
       }
       "adm2": {
-        "daily_alerts" = "f328893b-1a53-4d11-b00a-e6f5767db1be",
-        "weekly_alerts" = "a6195a49-7d58-4284-af29-24dc7ddd627f"
+        "daily_alerts" = ["f328893b-1a53-4d11-b00a-e6f5767db1be"]
+        "weekly_alerts" = ["a6195a49-7d58-4284-af29-24dc7ddd627f"]
       }
     }
     "firealerts_viirs": {
-      "all" = "9223ef23-7329-4987-8720-b5a87305f57d"
+      "all" = ["9223ef23-7329-4987-8720-b5a87305f57d"]
       "iso": {
-        "weekly_alerts" = "17ff682d-6ef2-4934-9a0e-8dddb95e5c45"
+        "weekly_alerts" = ["17ff682d-6ef2-4934-9a0e-8dddb95e5c45"]
       }
       "adm1": {
-        "weekly_alerts" = "0ebb725e-42e1-4a1f-8875-930d6f51113c"
+        "weekly_alerts" = ["0ebb725e-42e1-4a1f-8875-930d6f51113c"]
       }
       "adm2": {
-        "daily_alerts" = "6e451fd5-5241-451b-872f-27f7b87e6a5d"
-        "weekly_alerts" = "8836395d-5173-45b8-bc3c-9dce271feb31"
+        "daily_alerts" = ["6e451fd5-5241-451b-872f-27f7b87e6a5d"]
+        "weekly_alerts" = ["8836395d-5173-45b8-bc3c-9dce271feb31"]
       }
     }
     "firealerts_modis": {
       "iso": {
-        "weekly_alerts" = "58fee933-81bd-45bd-a1eb-6a37972e7c28"
+        "weekly_alerts" = ["58fee933-81bd-45bd-a1eb-6a37972e7c28"]
       }
       "adm1": {
-        "weekly_alerts" = "aae20051-c216-4b42-96d0-e8befc34f1cf"
+        "weekly_alerts" = ["aae20051-c216-4b42-96d0-e8befc34f1cf"]
       }
       "adm2": {
-        "daily_alerts" = "7dfa052a-155a-4159-b3ba-d0f81152662e"
-        "weekly_alerts" = "03e08f73-135a-464d-9ec3-ded08e6c69dd"
+        "daily_alerts" = ["7dfa052a-155a-4159-b3ba-d0f81152662e"]
+        "weekly_alerts" = ["03e08f73-135a-464d-9ec3-ded08e6c69dd"]
       }
     }
   }
   "wdpa": {
     "gladalerts": {
-      "daily_alerts" = "99b1e1ea-eea8-4212-9868-ee4b69f1b268",
-      "weekly_alerts" = "7e0669c2-e35b-4fa4-9e06-7a3c8e0cd767"
+      "daily_alerts" = ["99b1e1ea-eea8-4212-9868-ee4b69f1b268"]
+      "weekly_alerts" = ["7e0669c2-e35b-4fa4-9e06-7a3c8e0cd767"]
     }
     "firealerts_modis": {
-      "daily_alerts" = "5be51b58-43f7-4973-aebf-46ae11ac62ba"
-      "weekly_alerts" = "a1e38d65-1e1f-4e2c-ba66-f7c449a82a9a"
+      "daily_alerts" = ["5be51b58-43f7-4973-aebf-46ae11ac62ba"]
+      "weekly_alerts" = ["a1e38d65-1e1f-4e2c-ba66-f7c449a82a9a"]
     }
     "firealerts_viirs": {
-      "daily_alerts" = "c8040782-9dbb-4f6a-a8f8-51d43afdf81a"
-      "weekly_alerts" = "9b984feb-2d16-4414-9bf2-08235e3f3cc5"
+      "daily_alerts" = ["c8040782-9dbb-4f6a-a8f8-51d43afdf81a"]
+      "weekly_alerts" = ["9b984feb-2d16-4414-9bf2-08235e3f3cc5"]
     }
   }
 }

--- a/tests/mock_environment/mock_environment.py
+++ b/tests/mock_environment/mock_environment.py
@@ -20,37 +20,37 @@ os.environ["DATASETS"] = json.dumps(
     {
         "geostore": {
             "gladalerts": {
-                "daily_alerts": "testid_daily_alerts_glad",
-                "weekly_alerts": "testid_weekly_alerts_glad",
-                "summary": "testid_summary_glad",
-                "whitelist": "testid_whitelist_glad",
+                "daily_alerts": ["testid_daily_alerts_glad"],
+                "weekly_alerts": ["testid_weekly_alerts_glad"],
+                "summary": ["testid_summary_glad"],
+                "whitelist": ["testid_whitelist_glad"],
             },
             "annualupdate_minimal": {
-                "change": "testid_change_tcl",
-                "summary": "testid_summary_tcl",
-                "whitelist": "testid_whitelist_tcl",
+                "change": ["testid_change_tcl"],
+                "summary": ["testid_summary_tcl"],
+                "whitelist": ["testid_whitelist_tcl"],
             },
         },
         "gadm": {
             "gladalerts": {
                 "iso": {
-                    "weekly_alerts": "testid_weekly_alerts_glad_iso",
+                    "weekly_alerts": ["testid_weekly_alerts_glad_iso"],
                 },  # noqa: E231
                 "adm1": {
-                    "weekly_alerts": "testid_weekly_alerts_glad_adm1",
+                    "weekly_alerts": ["testid_weekly_alerts_glad_adm1"],
                 },  # noqa: E231
                 "adm2": {
-                    "daily_alerts": "testid_daily_alerts_glad_adm2",
-                    "weekly_alerts": "testid_weekly_alerts_glad_adm2",
+                    "daily_alerts": ["testid_daily_alerts_glad_adm2"],
+                    "weekly_alerts": ["testid_weekly_alerts_glad_adm2"],
                 },
             },
         },
         "wdpa": {
             "gladalerts": {
-                "daily_alerts": "testid_daily_alerts_wdpa",
-                "weekly_alerts": "testid_weekly_alerts_wdpa",
-                "summary": "testid_summary_wdpa",
-                "whitelist": "testid_whitelist_wdpa",
+                "daily_alerts": ["testid_daily_alerts_wdpa"],
+                "weekly_alerts": ["testid_weekly_alerts_wdpa"],
+                "summary": ["testid_summary_wdpa"],
+                "whitelist": ["testid_whitelist_wdpa"],
             },
         },
     },

--- a/tests/mocked_environment_tests/test_check_new_glad_alerts.py
+++ b/tests/mocked_environment_tests/test_check_new_glad_alerts.py
@@ -71,8 +71,8 @@ def test_handler_alerts_found():
     assert geostore_result["analyses"] == ["gladalerts"]
     assert geostore_result["datasets"] == {
         "gladalerts": {
-            "daily_alerts": "testid_daily_alerts_glad",
-            "weekly_alerts": "testid_weekly_alerts_glad",
+            "daily_alerts": ["testid_daily_alerts_glad"],
+            "weekly_alerts": ["testid_weekly_alerts_glad"],
         },
     }
     assert (

--- a/tests/mocked_environment_tests/test_step_functions.py
+++ b/tests/mocked_environment_tests/test_step_functions.py
@@ -319,22 +319,22 @@ INSTANCE_COUNT = 10
 RESULT_DIR = f"geotrellis/results/test/{get_date_string()}"
 DATASETS = {
     "gladalerts": {
-        "daily_alerts": "testid_daily_alerts_glad",
-        "weekly_alerts": "testid_weekly_alerts_glad",
-        "summary": "testid_summary_glad",
+        "daily_alerts": ["testid_daily_alerts_glad"],
+        "weekly_alerts": ["testid_weekly_alerts_glad"],
+        "summary": ["testid_summary_glad"],
     },
     "annualupdate_minimal": {
-        "change": "testid_change_tcl",
-        "summary": "testid_summary_tcl",
+        "change": ["testid_change_tcl"],
+        "summary": ["testid_summary_tcl"],
     },
 }
 DATASETS_CREATE = {
     "gladalerts": {
-        "daily_alerts": "Daily Alerts GLAD",
-        "weekly_alerts": "Weekly Alerts GLAD",
-        "summary": "Summary GLAD",
+        "daily_alerts": ["Daily Alerts GLAD"],
+        "weekly_alerts": ["Weekly Alerts GLAD"],
+        "summary": ["Summary GLAD"],
     },
-    "annualupdate_minimal": {"change": "Change TCL", "summary": "Summary TCL"},
+    "annualupdate_minimal": {"change": ["Change TCL"], "summary": ["Summary TCL"]},
 }
 DATASET_IDS = {
     "Daily Alerts GLAD": "testid_daily_alerts_glad",

--- a/tests/mocked_environment_tests/test_summary_analysis.py
+++ b/tests/mocked_environment_tests/test_summary_analysis.py
@@ -157,17 +157,17 @@ def test_get_dataset_result_paths():
     analyses = ["gladalerts", "annualupdate_minimal", "firealerts"]
     dataset_ids = {
         "gladalerts": {
-            "daily_alerts": "testid_daily_alerts_glad",
-            "weekly_alerts": "testid_weekly_alerts_glad",
-            "summary": "testid_summary_glad",
+            "daily_alerts": ["testid_daily_alerts_glad", "testid_daily_alerts_glad_2"],
+            "weekly_alerts": ["testid_weekly_alerts_glad"],
+            "summary": ["testid_summary_glad"],
         },
         "annualupdate_minimal": {
-            "change": "testid_change_tcl",
-            "summary": "testid_summary_tcl",
+            "change": ["testid_change_tcl"],
+            "summary": ["testid_summary_tcl"],
         },
         "firealerts_viirs": {
-            "change": "testid_change_viirs",
-            "all": "testid_all_viirs",
+            "change": ["testid_change_viirs"],
+            "all": ["testid_all_viirs"],
         },
     }
 
@@ -187,6 +187,10 @@ def test_get_dataset_result_paths():
 
     assert (
         dataset_result_paths["testid_daily_alerts_glad"]
+        == f"{results_glad}/daily_alerts"
+    )
+    assert (
+        dataset_result_paths["testid_daily_alerts_glad_2"]
         == f"{results_glad}/daily_alerts"
     )
     assert (

--- a/tools/create_datasets.py
+++ b/tools/create_datasets.py
@@ -125,19 +125,37 @@ def get_dataset_names(
             return {
                 "annualupdate_minimal": {
                     "iso": {
-                        "change": f"Tree Cover Loss {tcl_year} Change - GADM Iso level - {version}",
-                        "summary": f"Tree Cover Loss {tcl_year} Summary - GADM Iso level - {version}",
-                        "whitelist": f"Tree Cover Loss {tcl_year} Whitelist - GADM Iso level - {version}",
+                        "change": [
+                            f"Tree Cover Loss {tcl_year} Change - GADM Iso level - {version}"
+                        ],
+                        "summary": [
+                            f"Tree Cover Loss {tcl_year} Summary - GADM Iso level - {version}"
+                        ],
+                        "whitelist": [
+                            f"Tree Cover Loss {tcl_year} Whitelist - GADM Iso level - {version}"
+                        ],
                     },
                     "adm1": {
-                        "change": f"Tree Cover Loss {tcl_year} Change - GADM Adm1 level - {version}",
-                        "summary": f"Tree Cover Loss {tcl_year} Summary - GADM Adm1 level - {version}",
-                        "whitelist": f"Tree Cover Loss {tcl_year} Whitelist - GADM Adm1 level - {version}",
+                        "change": [
+                            f"Tree Cover Loss {tcl_year} Change - GADM Adm1 level - {version}"
+                        ],
+                        "summary": [
+                            f"Tree Cover Loss {tcl_year} Summary - GADM Adm1 level - {version}"
+                        ],
+                        "whitelist": [
+                            f"Tree Cover Loss {tcl_year} Whitelist - GADM Adm1 level - {version}"
+                        ],
                     },
                     "adm2": {
-                        "change": f"Tree Cover Loss {tcl_year} Change - GADM Adm2 level - {version}",
-                        "summary": f"Tree Cover Loss {tcl_year} Summary - GADM Adm2 level - {version}",
-                        "whitelist": f"Tree Cover Loss {tcl_year} Whitelist - GADM Adm2 level - {version}",
+                        "change": [
+                            f"Tree Cover Loss {tcl_year} Change - GADM Adm2 level - {version}"
+                        ],
+                        "summary": [
+                            f"Tree Cover Loss {tcl_year} Summary - GADM Adm2 level - {version}"
+                        ],
+                        "whitelist": [
+                            f"Tree Cover Loss {tcl_year} Whitelist - GADM Adm2 level - {version}"
+                        ],
                     },
                 },
             }
@@ -145,20 +163,40 @@ def get_dataset_names(
             return {
                 "gladalerts": {
                     "iso": {
-                        "weekly_alerts": f"Glad Alerts Weekly Change - GADM Iso level - {version}",
-                        "summary": f"Glad Alerts Summary - GADM Iso level - {version}",
-                        "whitelist": f"Glad Alerts Whitelist - GADM Iso level - {version}",
+                        "weekly_alerts": [
+                            f"Glad Alerts Weekly Change - GADM Iso level - {version}"
+                        ],
+                        "summary": [
+                            f"Glad Alerts Summary - GADM Iso level - {version}"
+                        ],
+                        "whitelist": [
+                            f"Glad Alerts Whitelist - GADM Iso level - {version}"
+                        ],
                     },
                     "adm1": {
-                        "weekly_alerts": f"Glad Alerts Weekly Change - GADM Adm1 level - {version}",
-                        "summary": f"Glad Alerts Summary - GADM Adm1 level - {version}",
-                        "whitelist": f"Glad Alerts Whitelist - GADM Adm1 level - {version}",
+                        "weekly_alerts": [
+                            f"Glad Alerts Weekly Change - GADM Adm1 level - {version}"
+                        ],
+                        "summary": [
+                            f"Glad Alerts Summary - GADM Adm1 level - {version}"
+                        ],
+                        "whitelist": [
+                            f"Glad Alerts Whitelist - GADM Adm1 level - {version}"
+                        ],
                     },
                     "adm2": {
-                        "daily_alerts": f"Glad Alerts Daily Change - GADM Adm2 level - {version}",
-                        "weekly_alerts": f"Glad Alerts Weekly Change - GADM Adm2 level - {version}",
-                        "summary": f"Glad Alerts Summary - GADM Adm2 level - {version}",
-                        "whitelist": f"Glad Alerts Whitelist - GADM Adm2 level - {version}",
+                        "daily_alerts": [
+                            f"Glad Alerts Daily Change - GADM Adm2 level - {version}"
+                        ],
+                        "weekly_alerts": [
+                            f"Glad Alerts Weekly Change - GADM Adm2 level - {version}"
+                        ],
+                        "summary": [
+                            f"Glad Alerts Summary - GADM Adm2 level - {version}"
+                        ],
+                        "whitelist": [
+                            f"Glad Alerts Whitelist - GADM Adm2 level - {version}"
+                        ],
                     },
                 },
             }
@@ -166,17 +204,31 @@ def get_dataset_names(
             datasets = {
                 f"firealerts_{fire_alert_type.lower()}": {
                     "iso": {
-                        "whitelist": f"{fire_alert_type.upper()} Fire Alerts Whitelist - GADM Iso level - {version}",
-                        "weekly_alerts": f"{fire_alert_type.upper()} Fire Alerts Weekly Change - GADM Iso level - {version}",
+                        "whitelist": [
+                            f"{fire_alert_type.upper()} Fire Alerts Whitelist - GADM Iso level - {version}"
+                        ],
+                        "weekly_alerts": [
+                            f"{fire_alert_type.upper()} Fire Alerts Weekly Change - GADM Iso level - {version}"
+                        ],
                     },
                     "adm1": {
-                        "whitelist": f"{fire_alert_type.upper()} Fire Alerts Whitelist - GADM Adm1 level - {version}",
-                        "weekly_alerts": f"{fire_alert_type.upper()} Fire Alerts Weekly Change - GADM Adm1 level - {version}",
+                        "whitelist": [
+                            f"{fire_alert_type.upper()} Fire Alerts Whitelist - GADM Adm1 level - {version}"
+                        ],
+                        "weekly_alerts": [
+                            f"{fire_alert_type.upper()} Fire Alerts Weekly Change - GADM Adm1 level - {version}"
+                        ],
                     },
                     "adm2": {
-                        "whitelist": f"{fire_alert_type.upper()} Fire Alerts Whitelist - GADM Adm2 level - {version}",
-                        "daily_alerts": f"{fire_alert_type.upper()} Fire Alerts Daily Change - GADM Adm2 level - {version}",
-                        "weekly_alerts": f"{fire_alert_type.upper()} Fire Alerts Weekly Change - GADM Adm2 level - {version}",
+                        "whitelist": [
+                            f"{fire_alert_type.upper()} Fire Alerts Whitelist - GADM Adm2 level - {version}"
+                        ],
+                        "daily_alerts": [
+                            f"{fire_alert_type.upper()} Fire Alerts Daily Change - GADM Adm2 level - {version}"
+                        ],
+                        "weekly_alerts": [
+                            f"{fire_alert_type.upper()} Fire Alerts Weekly Change - GADM Adm2 level - {version}"
+                        ],
                     },
                 },
             }
@@ -190,52 +242,78 @@ def get_dataset_names(
         if analysis == "annualupdate_minimal":
             return {
                 "annualupdate_minimal": {
-                    "change": f"Tree Cover Loss {tcl_year} Change - WDPA- {version}",
-                    "summary": f"Tree Cover Loss {tcl_year} Summary - WDPA - {version}",
-                    "whitelist": f"Tree Cover Loss {tcl_year} Whitelist - WDPA - {version}",
+                    "change": [f"Tree Cover Loss {tcl_year} Change - WDPA- {version}"],
+                    "summary": [
+                        f"Tree Cover Loss {tcl_year} Summary - WDPA - {version}"
+                    ],
+                    "whitelist": [
+                        f"Tree Cover Loss {tcl_year} Whitelist - WDPA - {version}"
+                    ],
                 },
             }
         elif analysis == "gladalerts":
             return {
                 "gladalerts": {
-                    "daily_alerts": f"Glad Alerts Daily Change - WDPA - {version}",
-                    "weekly_alerts": f"Glad Alerts Weekly Change - WDPA - {version}",
-                    "summary": f"Glad Alerts Summary - WDPA - {version}",
-                    "whitelist": f"Glad Alerts Whitelist - WDPA - {version}",
+                    "daily_alerts": [f"Glad Alerts Daily Change - WDPA - {version}"],
+                    "weekly_alerts": [f"Glad Alerts Weekly Change - WDPA - {version}"],
+                    "summary": [f"Glad Alerts Summary - WDPA - {version}"],
+                    "whitelist": [f"Glad Alerts Whitelist - WDPA - {version}"],
                 },
             }
         elif analysis == "firealerts":
             return {
                 f"firealerts_{fire_alert_type.lower()}": {
-                    "daily_alerts": f"{fire_alert_type.upper()} Fire Alerts Daily Change - WDPA - {version}",
-                    "weekly_alerts": f"{fire_alert_type.upper()} Fire Alerts Weekly Change - WDPA - {version}",
-                    "whitelist": f"{fire_alert_type.upper()} Fire Alerts Whitelist - WDPA - {version}",
+                    "daily_alerts": [
+                        f"{fire_alert_type.upper()} Fire Alerts Daily Change - WDPA - {version}"
+                    ],
+                    "weekly_alerts": [
+                        f"{fire_alert_type.upper()} Fire Alerts Weekly Change - WDPA - {version}"
+                    ],
+                    "whitelist": [
+                        f"{fire_alert_type.upper()} Fire Alerts Whitelist - WDPA - {version}"
+                    ],
                 },
             }
     elif feature_type == "geostore":
         if analysis == "annualupdate_minimal":
             return {
                 "annualupdate_minimal": {
-                    "change": f"Tree Cover Loss {tcl_year} Change - Geostore - {version}",
-                    "summary": f"Tree Cover Loss {tcl_year} Summary - Geostore - {version}",
-                    "whitelist": f"Tree Cover Loss {tcl_year} Whitelist - Geostore - {version}",
+                    "change": [
+                        f"Tree Cover Loss {tcl_year} Change - Geostore - {version}"
+                    ],
+                    "summary": [
+                        f"Tree Cover Loss {tcl_year} Summary - Geostore - {version}"
+                    ],
+                    "whitelist": [
+                        f"Tree Cover Loss {tcl_year} Whitelist - Geostore - {version}"
+                    ],
                 },
             }
         elif analysis == "gladalerts":
             return {
                 "gladalerts": {
-                    "daily_alerts": f"Glad Alerts Daily Change - Geostore - {version}",
-                    "weekly_alerts": f"Glad Alerts Weekly Change - Geostore - {version}",
-                    "summary": f"Glad Alerts Summary - Geostore - {version}",
-                    "whitelist": f"Glad Alerts Whitelist - Geostore - {version}",
+                    "daily_alerts": [
+                        f"Glad Alerts Daily Change - Geostore - {version}"
+                    ],
+                    "weekly_alerts": [
+                        f"Glad Alerts Weekly Change - Geostore - {version}"
+                    ],
+                    "summary": [f"Glad Alerts Summary - Geostore - {version}"],
+                    "whitelist": [f"Glad Alerts Whitelist - Geostore - {version}"],
                 }
             }
         elif analysis == "firealerts":
             return {
                 f"firealerts_{fire_alert_type.lower()}": {
-                    "daily_alerts": f"{fire_alert_type.upper()} Fire Alerts Daily Change - Geostore - {version}",
-                    "weekly_alerts": f"{fire_alert_type.upper()} Fire Alerts Weekly Change - Geostore - {version}",
-                    "whitelist": f"{fire_alert_type.upper()} Fire Alerts Whitelist - Geostore - {version}",
+                    "daily_alerts": [
+                        f"{fire_alert_type.upper()} Fire Alerts Daily Change - Geostore - {version}"
+                    ],
+                    "weekly_alerts": [
+                        f"{fire_alert_type.upper()} Fire Alerts Weekly Change - Geostore - {version}"
+                    ],
+                    "whitelist": [
+                        f"{fire_alert_type.upper()} Fire Alerts Whitelist - Geostore - {version}"
+                    ],
                 },
             }
 


### PR DESCRIPTION
Allow multiple datasets to updated simultaneously for the same geotrellis results, so we can overlap new and old datasets.

To do this, just changing the dataset ID config to have the dataset IDs as a list instead of a scalar. Then iterate that list to generate the same source paths. The change was pretty minor, must of the changes are updating existing terraform and test configs to use a list instead of a scalar. 