### PR TITLE
Temp fixes to get integrated alerts out

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -11,7 +11,7 @@ COPY . $WORKDIR
 # installing dependencies to build package
 RUN pip install . -t python
 
-# change 833238432343343323
+# change 8332345438432343343323
 
 # Precompile all python packages and remove .py files
 RUN find python/ -type f -name '*.pyc' -print0 | xargs -0 rm -rf

--- a/src/datapump/jobs/geotrellis.py
+++ b/src/datapump/jobs/geotrellis.py
@@ -626,6 +626,61 @@ class GeotrellisJob(Job):
         if self.change_only:
             step_args.append("--change_only")
 
+        # TODO temp fix until we start sending all versions from datapump to geotrellis
+        if self.table.analysis == Analysis.integrated_alerts:
+            client = DataApiClient()
+            alert_datasets = [
+                "umd_glad_landsat_alerts",
+                "umd_glad_sentinel2_alerts",
+                "wur_radd_alerts",
+            ]
+
+            for ds in alert_datasets:
+                latest_version = client.get_latest_version(ds)
+                step_args.append("--pin_version")
+                step_args.append(f"{ds}:{latest_version}")
+
+            step_args += [
+                "--pin_version",
+                "gfw_wood_fiber:v20200725",
+                "--pin_version",
+                "whrc_aboveground_biomass_stock_2000:v4",
+                "--pin_version",
+                "umd_regional_primary_forest_2001:v201901",
+                "--pin_version",
+                "wdpa_protected_areas:v202106",
+                "--pin_version",
+                "birdlife_alliance_for_zero_extinction_sites:v20200725",
+                "--pin_version",
+                "birdlife_key_biodiversity_areas:v202106",
+                "--pin_version",
+                "landmark_indigenous_and_community_lands:v20201215",
+                "--pin_version",
+                "gfw_mining_concessions:v202106",
+                "--pin_version",
+                "gfw_managed_forests:v202106",
+                "--pin_version",
+                "rspo_oil_palm:v20200114",
+                "--pin_version",
+                "gfw_peatlands:v20200807",
+                "--pin_version",
+                "idn_forest_moratorium:v20200923",
+                "--pin_version",
+                "gfw_oil_palm:v20191031",
+                "--pin_version",
+                "idn_forest_area:v201709",
+                "--pin_version",
+                "per_forest_concessions:v201610",
+                "--pin_version",
+                "gfw_oil_gas:v20190321",
+                "--pin_version",
+                "gmw_global_mangrove_extent_2016:v20201210",
+                "--pin_version",
+                "ifl_intact_forest_landscapes:v2018",
+                "--pin_version",
+                "ibge_bra_biomes:v2004",
+            ]
+
         if (
             GLOBALS.env != "production"
             and self.feature_type == GeotrellisFeatureType.gadm
@@ -712,7 +767,7 @@ class GeotrellisJob(Job):
                                     {
                                         "VolumeSpecification": {
                                             "VolumeType": "gp2",
-                                            "SizeInGB": 10,
+                                            "SizeInGB": 60,
                                         },
                                         "VolumesPerInstance": 1,
                                     }
@@ -734,7 +789,7 @@ class GeotrellisJob(Job):
                                     {
                                         "VolumeSpecification": {
                                             "VolumeType": "gp2",
-                                            "SizeInGB": 10,
+                                            "SizeInGB": 60,
                                         },
                                         "VolumesPerInstance": 1,
                                     }

--- a/tests/files/mock_geotrellis/src/main/java/MockGeotrellis.java
+++ b/tests/files/mock_geotrellis/src/main/java/MockGeotrellis.java
@@ -7,7 +7,7 @@ public class MockGeotrellis {
 
         System.out.println(joined);
 
-        if (!joined.equals(expectedGladUpdateStep) && !joined.equals(expectedGladSyncStep) && !joined.equals(expectedIntegratedAlertsSyncStep)) {
+        if (!joined.equals(expectedGladUpdateStep) && !joined.equals(expectedGladSyncStep) && !joined.startsWith(expectedIntegratedAlertsSyncStep)) {
             throw new Exception("Invalid step args");
         }
     }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Versions for integrated alert contextual layers come dynamically from checking API, but the way we do it, it hits the API thousands of times quickly. This eventually causes tons of error messages, which causes failures with the process and probably temporarily takes down the API.

Issue Number: N/A


## What is the new behavior?

- This is fixed in the newest geotrellis, but that's tied with some other changes for Q4, so adding this temp fix to get integrated alerts out
- Just pin all the versions used in this analysis in the input, so geotrellis won't try to reach out to the API
- Also increase the EBS volume size, because sometimes we're running out of disk space with all this processing.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


