### PR TITLE
Disable extra indices for integrated alerts

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -11,7 +11,7 @@ COPY . $WORKDIR
 # installing dependencies to build package
 RUN pip install . -t python
 
-# change 8332345438432343343323
+# change 8324332345438432343343323
 
 # Precompile all python packages and remove .py files
 RUN find python/ -type f -name '*.pyc' -print0 | xargs -0 rm -rf

--- a/src/datapump/jobs/geotrellis.py
+++ b/src/datapump/jobs/geotrellis.py
@@ -422,26 +422,27 @@ class GeotrellisJob(Job):
         if analysis_agg == "all":
             cluster = Index(index_type="gist", column_names=["geom_wm"])
             indices += [Index(index_type="gist", column_names=["geom"]), cluster]
-        elif (
-            self.table.analysis == Analysis.integrated_alerts
-            and analysis_agg == "daily_alerts"
-        ):
-            # this table is multi-use, so also create indices for individual alerts
-            glad_l_cols = [
-                "umd_glad_landsat_alerts__confidence",
-                "umd_glad_landsat_alerts__date",
-            ]
-            glad_s2_cols = [
-                "umd_glad_sentinel2_alerts__confidence",
-                "umd_glad_sentinel2_alerts__date",
-            ]
-            wur_radd_cols = ["wur_radd_alerts__confidence", "wur_radd_alerts__date"]
-
-            indices += [
-                Index(index_type="btree", column_names=id_cols + glad_l_cols),
-                Index(index_type="btree", column_names=id_cols + glad_s2_cols),
-                Index(index_type="btree", column_names=id_cols + wur_radd_cols),
-            ]
+        # FIXME is there a way to do this without using all the local storage on aurora?
+        # elif (
+        #     self.table.analysis == Analysis.integrated_alerts
+        #     and analysis_agg == "daily_alerts"
+        # ):
+        #     # this table is multi-use, so also create indices for individual alerts
+        #     glad_l_cols = [
+        #         "umd_glad_landsat_alerts__confidence",
+        #         "umd_glad_landsat_alerts__date",
+        #     ]
+        #     glad_s2_cols = [
+        #         "umd_glad_sentinel2_alerts__confidence",
+        #         "umd_glad_sentinel2_alerts__date",
+        #     ]
+        #     wur_radd_cols = ["wur_radd_alerts__confidence", "wur_radd_alerts__date"]
+        #
+        #     indices += [
+        #         Index(index_type="btree", column_names=id_cols + glad_l_cols),
+        #         Index(index_type="btree", column_names=id_cols + glad_s2_cols),
+        #         Index(index_type="btree", column_names=id_cols + wur_radd_cols),
+        #     ]
 
         return indices, cluster
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
When creating integrated alerts table, we create indices on the fields for every alert system. These are large indices, and the API will create them in parallel, which can use up all the temp space on aurora, causing them to fail.


## What is the new behavior?
For now, let's just only create an index for the default widget (the integrated date and confidence).

## Does this introduce a breaking change?

- [ ] Yes
- [X] No