### PR TITLE
Add more retries for API and geotrellis

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = boto3,botocore,datapump,dateutil,google,pydantic,pytest,requests,setuptools,shapefile,shapely
+known_third_party = boto3,botocore,datapump,dateutil,google,pydantic,pytest,requests,retry,setuptools,shapefile,shapely

--- a/src/setup.py
+++ b/src/setup.py
@@ -15,5 +15,6 @@ setup(
         "pyshp~=2.1.0",
         "pydantic~=1.7.2",
         "smart-open~=4.0.1",
+        "retry~=0.9.2",
     ],  # noqa: E231
 )

--- a/terraform/modules/datapump/cloudwatch.tf
+++ b/terraform/modules/datapump/cloudwatch.tf
@@ -1,26 +1,26 @@
 resource "aws_cloudwatch_event_rule" "everyday-11-pm-est" {
   name                = substr("everyday-11-pm-est${local.name_suffix}", 0, 64)
   description         = "Run everyday at 11 pm EST"
-  schedule_expression = "cron(0 7 ? * * *)" // -5 to EST
+  schedule_expression = "cron(0 7 ? * * *)"
   tags                = local.tags
 }
 
-resource "aws_cloudwatch_event_rule" "everyday-9-pm-est" {
-  name                = substr("everyday-9-pm-est${local.name_suffix}", 0, 64)
-  description         = "Run everyday at 9 pm EST"
-  schedule_expression = "cron(0 5 ? * * *)" // -5 to EST
+resource "aws_cloudwatch_event_rule" "everyday-7-pm-est" {
+  name                = substr("everyday-7-pm-est${local.name_suffix}", 0, 64)
+  description         = "Run everyday at 7 pm EST"
+  schedule_expression = "cron(0 3 ? * * *)"
   tags                = local.tags
 }
 
-resource "aws_cloudwatch_event_rule" "everyday-1-am-est" {
-  name                = substr("everyday-1-am-est${local.name_suffix}", 0, 64)
-  description         = "Run everyday at 1 am EST"
-  schedule_expression = "cron(0 9 ? * * *)" // -5 to EST
+resource "aws_cloudwatch_event_rule" "everyday-3-am-est" {
+  name                = substr("everyday-3-am-est${local.name_suffix}", 0, 64)
+  description         = "Run everyday at 3 am EST"
+  schedule_expression = "cron(0 11 ? * * *)"
   tags                = local.tags
 }
 
 resource "aws_cloudwatch_event_target" "nightly-sync-areas" {
-  rule      = aws_cloudwatch_event_rule.everyday-9-pm-est.name
+  rule      = aws_cloudwatch_event_rule.everyday-7-pm-est.name
   target_id = substr("${local.project}-nightly-sync-areas${local.name_suffix}", 0, 64)
   arn       = aws_sfn_state_machine.datapump.id
   input     = "{\"command\": \"sync\", \"parameters\": {\"types\": [\"rw_areas\", \"wur_radd_alerts\", \"umd_glad_landsat_alerts\", \"umd_glad_sentinel2_alerts\"]}}"
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_event_target" "nightly-sync" {
 }
 
 resource "aws_cloudwatch_event_target" "nightly-sync-integrated" {
-  rule      = aws_cloudwatch_event_rule.everyday-1-am-est.name
+  rule      = aws_cloudwatch_event_rule.everyday-3-am-est.name
   target_id = substr("${local.project}-nightly-sync${local.name_suffix}", 0, 64)
   arn       = aws_sfn_state_machine.datapump.id
   input    = "{\"command\": \"sync\", \"parameters\": {\"types\": [\"integrated_alerts\"]}}"

--- a/terraform/modules/datapump/variables.tf
+++ b/terraform/modules/datapump/variables.tf
@@ -38,7 +38,7 @@ variable "lambda_params" {
   default = {
     runtime = "python3.7"
     memory_size = 3048
-    timeout = 300
+    timeout = 900
   }
 }
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type


Please check the type of change your PR introduces:
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
-Pipeline will just fail if any API request fails
-The pipeline won't retry geotrellis jobs over a certain size
-All sync jobs are spaced 2 hours apart with the assumption they'll finish in that time
-API tables have complex multi-key indices/clusters that sometimes hit memory limits on Aurora


## What is the new behavior?

- Retry API requests a couple times, since some times we get 5XX errors during high load times, but the request will work if you wait a couple seconds and try again. This will make the pipelines much more stable.
-We now have a total timeout for the geotrellis run, so it's safe to retry big jobs. 
-The retry time is 4 hours, so we should space out sync jobs 4 hours in case a lot of long retries happen.
-Indices and clusters are simplified to just reporting unit IDs and date fields. Don't cluster for geostore tables, since the high number of IDs causes the cluster job to consistently hit postgres memory limits. 


## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
