### PR TITLE
Reduce data passed through step function to avoid limit

### DIFF
--- a/.github/workflows/terraform_build.yaml
+++ b/.github/workflows/terraform_build.yaml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN wget http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/ap
   rm apache-maven-$MAVEN_VERSION-bin.tar.gz && \
   mv apache-maven-$MAVEN_VERSION /usr/lib/mvn
 
-RUN apk add --no-cache --upgrade bash gcc libc-dev python3-dev geos-dev
+RUN apk add --no-cache --upgrade bash gcc libc-dev python3-dev geos-dev musl-dev linux-headers g++
 RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -11,7 +11,7 @@ COPY . $WORKDIR
 # installing dependencies to build package
 RUN pip install . -t python
 
-# change 31850
+# change 31851
 
 # Precompile all python packages and remove .py files
 RUN find python/ -type f -name '*.pyc' -print0 | xargs -0 rm -rf

--- a/src/datapump/jobs/geotrellis.py
+++ b/src/datapump/jobs/geotrellis.py
@@ -122,6 +122,11 @@ class GeotrellisJob(Job):
         elif self.step == GeotrellisJobStep.uploading:
             self.status = self.check_upload()
 
+            # clear result tables after completion, combining these after
+            # the Map state can go over the Step Function message size limit
+            if self.status == JobStatus.complete:
+                self.result_tables = []
+
     def start_analysis(self):
         self.emr_job_id = self._run_job_flow(*self._get_emr_inputs())
 
@@ -856,7 +861,7 @@ class GeotrellisJob(Job):
             "spark.driver.cores": "1",
             "spark.executor.cores": "1",
             "spark.yarn.executor.memoryOverhead": "1G",
-            "spark.dynamicAllocation.enabled": "false",
+            "spark.dynamicAllocation.enabled": "false"
         }
 
         if self.geotrellis_version >= "2.0.0":

--- a/src/lambdas/dispatcher/src/lambda_function.py
+++ b/src/lambdas/dispatcher/src/lambda_function.py
@@ -14,6 +14,7 @@ from datapump.jobs.geotrellis import FireAlertsGeotrellisJob, GeotrellisJob
 from datapump.jobs.jobs import JobStatus
 from datapump.jobs.version_update import RasterVersionUpdateJob
 from datapump.sync.sync import Syncer
+from datapump.util.util import log_and_notify_error
 from pydantic import ValidationError, parse_obj_as
 
 
@@ -54,7 +55,7 @@ def handler(event, context):
     except ValidationError as e:
         return {"statusCode": 400, "body": {"message": "Validation error", "detail": e}}
     except Exception as e:
-        LOGGER.exception(f"Exception caught while running update: {e}")
+        log_and_notify_error(f"Exception caught while running update: {e}")
         raise e
 
 

--- a/src/lambdas/dispatcher/src/lambda_function.py
+++ b/src/lambdas/dispatcher/src/lambda_function.py
@@ -14,7 +14,7 @@ from datapump.jobs.geotrellis import FireAlertsGeotrellisJob, GeotrellisJob
 from datapump.jobs.jobs import JobStatus
 from datapump.jobs.version_update import RasterVersionUpdateJob
 from datapump.sync.sync import Syncer
-from datapump.util.util import log_and_notify_error
+from datapump.util.util import error
 from pydantic import ValidationError, parse_obj_as
 
 
@@ -55,7 +55,7 @@ def handler(event, context):
     except ValidationError as e:
         return {"statusCode": 400, "body": {"message": "Validation error", "detail": e}}
     except Exception as e:
-        log_and_notify_error(f"Exception caught while running update: {e}")
+        error(f"Exception caught while running update: {e}")
         raise e
 
 

--- a/terraform/modules/datapump/cloudwatch.tf
+++ b/terraform/modules/datapump/cloudwatch.tf
@@ -19,25 +19,52 @@ resource "aws_cloudwatch_event_rule" "everyday-3-am-est" {
   tags                = local.tags
 }
 
-resource "aws_cloudwatch_event_target" "nightly-sync-areas" {
+resource "aws_cloudwatch_event_target" "sync-areas" {
   rule      = aws_cloudwatch_event_rule.everyday-7-pm-est.name
   target_id = substr("${local.project}-nightly-sync-areas${local.name_suffix}", 0, 64)
   arn       = aws_sfn_state_machine.datapump.id
-  input     = "{\"command\": \"sync\", \"parameters\": {\"types\": [\"rw_areas\", \"wur_radd_alerts\", \"umd_glad_landsat_alerts\", \"umd_glad_sentinel2_alerts\"]}}"
+  input     = "{\"command\": \"sync\", \"parameters\": {\"types\": [\"rw_areas\"]}}"
   role_arn  = aws_iam_role.datapump_states.arn
   count     = var.environment == "production" ? 1 : 0
 }
 
-resource "aws_cloudwatch_event_target" "nightly-sync" {
+resource "aws_cloudwatch_event_target" "sync-deforestation-alerts" {
+  rule      = aws_cloudwatch_event_rule.everyday-7-pm-est.name
+  target_id = substr("${local.project}-nightly-sync-areas${local.name_suffix}", 0, 64)
+  arn       = aws_sfn_state_machine.datapump.id
+  input     = "{\"command\": \"sync\", \"parameters\": {\"types\": [\"wur_radd_alerts\", \"umd_glad_landsat_alerts\", \"umd_glad_sentinel2_alerts\"]}}"
+  role_arn  = aws_iam_role.datapump_states.arn
+  count     = var.environment == "production" ? 1 : 0
+}
+
+resource "aws_cloudwatch_event_target" "sync-glad" {
   rule      = aws_cloudwatch_event_rule.everyday-11-pm-est.name
   target_id = substr("${local.project}-nightly-sync${local.name_suffix}", 0, 64)
   arn       = aws_sfn_state_machine.datapump.id
-  input    = "{\"command\": \"sync\", \"parameters\": {\"types\": [\"glad\", \"viirs\", \"modis\"]}}"
+  input    = "{\"command\": \"sync\", \"parameters\": {\"types\": [\"glad\"]}}"
   role_arn  = aws_iam_role.datapump_states.arn
   count     = var.environment == "production" ? 1 : 0
 }
 
-resource "aws_cloudwatch_event_target" "nightly-sync-integrated" {
+resource "aws_cloudwatch_event_target" "sync-viirs" {
+  rule      = aws_cloudwatch_event_rule.everyday-11-pm-est.name
+  target_id = substr("${local.project}-nightly-sync${local.name_suffix}", 0, 64)
+  arn       = aws_sfn_state_machine.datapump.id
+  input    = "{\"command\": \"sync\", \"parameters\": {\"types\": [\"viirs\"]}}"
+  role_arn  = aws_iam_role.datapump_states.arn
+  count     = var.environment == "production" ? 1 : 0
+}
+
+resource "aws_cloudwatch_event_target" "sync-modis" {
+  rule      = aws_cloudwatch_event_rule.everyday-11-pm-est.name
+  target_id = substr("${local.project}-nightly-sync${local.name_suffix}", 0, 64)
+  arn       = aws_sfn_state_machine.datapump.id
+  input    = "{\"command\": \"sync\", \"parameters\": {\"types\": [\"modis\"]}}"
+  role_arn  = aws_iam_role.datapump_states.arn
+  count     = var.environment == "production" ? 1 : 0
+}
+
+resource "aws_cloudwatch_event_target" "sync-integrated-alerts" {
   rule      = aws_cloudwatch_event_rule.everyday-3-am-est.name
   target_id = substr("${local.project}-nightly-sync${local.name_suffix}", 0, 64)
   arn       = aws_sfn_state_machine.datapump.id


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type


Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Sync jobs run in a parallel Map state and combine their output when finished to a postprocessing lambda. For geotrellis updates, the sync jobs each pass all info about the tables they upload, including all source URIs and creation options. For some step functions, it's hitting going over the 256 KB message limit when combining the outputs, which causes an uncatchable silent failure. This leaves the step function in a partially complete state.

## What is the new behavior?

- Remove the table URIs/creation options from the output of the messages once the sync job is complete, as it isn't necessary at all for postprocessing. This reduces the data output a lot.
- Split all sync types into separate step functions. This will reduce the amount of data passed through each, and also decouples each sync type more.
- Make sure errors caught in the entrypoint lambda are reported to slack.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

