### PR TITLE
Extend partitions for VIIRS to 2030

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -11,7 +11,7 @@ COPY . $WORKDIR
 # installing dependencies to build package
 RUN pip install . -t python
 
-# change 31851
+# change 31852
 
 # Precompile all python packages and remove .py files
 RUN find python/ -type f -name '*.pyc' -print0 | xargs -0 rm -rf

--- a/src/datapump/jobs/geotrellis.py
+++ b/src/datapump/jobs/geotrellis.py
@@ -477,7 +477,7 @@ class GeotrellisJob(Job):
         if analysis_agg == "all":
             # for all points, partition by month
             partition_schema = []
-            for year in range(2012, 2023):
+            for year in range(2012, 2030):
                 for month in range(1, 13):
                     start_value = date(year, month, 1).strftime("%Y-%m-%d")
                     end_month = month + 1 if month < 12 else 1


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Partitions only go to 1/1/2023, causing newer data to fail because it can't find a partition.

Issue Number: GTC-2211


## What is the new behavior?
Create partitions for 2030 instead of 2023.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

