### PR TITLE
Disable VIIRS table clustering

### DIFF
--- a/src/datapump/jobs/geotrellis.py
+++ b/src/datapump/jobs/geotrellis.py
@@ -453,7 +453,10 @@ class GeotrellisJob(Job):
             cluster = None
 
         if analysis_agg == "all":
-            cluster = Index(index_type="gist", column_names=["geom_wm"])
+            # TODO this clustering always fails because it goes beyond the
+            # memory limits of our DB instance. Disable for now since after
+            # a month the clustering won't even matter anymore.
+            cluster = None  # Index(index_type="gist", column_names=["geom_wm"])
             indices += [Index(index_type="gist", column_names=["geom"]), cluster]
         elif (
             self.table.analysis == Analysis.integrated_alerts


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
We attempt to create a GIST (spatial) partition for the massive 100 million+  rows VIIRS alerts table. This has always caused the table to fail at the end because the clustering is so intensive. I think we'd have to upgrade the whole DB instance to handle it, which would generally increase our DB costs.


## What is the new behavior?
Let's just disable clustering for this table until we can find a cost efficient workaround. The clustering is only applied on table creation anyway, so after a couple weeks it won't even matter because we only display recent VIIRS alerts on the map. The index should be sufficient.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

