### PR TITLE
Paginate S3 check for latest fire alerts

### DIFF
--- a/src/datapump/sync/fire_alerts.py
+++ b/src/datapump/sync/fire_alerts.py
@@ -141,12 +141,6 @@ def _get_last_saved_alert_time(nrt_s3_directory):
         return "0000-00-00", "0000"
 
 
-def get_most_recent_s3_object(bucket_name, prefix):
-    """
-    Get last modified file at S3 bucket and prefix
-    """
-
-
 def _write_row(row, fields, writer):
     tsv_row = dict()
     for field in fields:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Checking for latest fire alert files by looking at the first page of an S3 list objects call (max 1000 objects).

Issue Number: GTC-2546


## What is the new behavior?
Paginate list objects and call and get latest fire alert file among all of them.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

