### PR TITLE
Increase integrated alerts job worker count and timeout

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -15,7 +15,7 @@ RUN pip install . -t python
 # to change the hash of the file and get TF to realize it needs to be
 # redeployed. Ticket for a better solution:
 # https://gfw.atlassian.net/browse/GTC-1250
-# change 1
+# change 2
 
 RUN yum install -y zip geos-devel
 

--- a/src/datapump/jobs/geotrellis.py
+++ b/src/datapump/jobs/geotrellis.py
@@ -664,11 +664,10 @@ class GeotrellisJob(Job):
 
         :return: number of workers appropriate for job size
         """
-        if (
-            self.sync_type == SyncType.rw_areas
-            or self.table.analysis == Analysis.integrated_alerts
-        ):
+        if self.sync_type == SyncType.rw_areas:
             return 30
+        elif self.table.analysis == Analysis.integrated_alerts:
+            return 60
         elif self.change_only and self.table.analysis == Analysis.glad:
             return 10
 

--- a/src/datapump/sync/sync.py
+++ b/src/datapump/sync/sync.py
@@ -251,6 +251,7 @@ class IntegratedAlertsSync(Sync):
                 ),
                 features_1x1=config.metadata["features_1x1"],
                 geotrellis_version=config.metadata["geotrellis_version"],
+                timeout_sec=6 * 3600,
             )
         )
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
We use 30 workers for integrated alerts updates on geotrellis, and timeout after 4 hours. The low worker count makes it sometimes go over the timeout limit.


## What is the new behavior?

- Increase worker count to 60 workers
- Increase timeout to 6 hours

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

