### PR TITLE
Workaround GTC-2986 by checking if version is successfully created after get 5XX response from API

### DIFF
--- a/src/datapump/clients/data_api.py
+++ b/src/datapump/clients/data_api.py
@@ -148,7 +148,7 @@ class DataApiClient:
         self, dataset: str, version: str, payload: Dict[str, Any]
     ) -> Dict[str, Any]:
         uri = f"{GLOBALS.data_api_uri}/dataset/{dataset}/{version}/assets"
-        return self.get_version(ValidMethods.post, uri, payload)["data"]
+        return self._send_request(ValidMethods.post, uri, payload)["data"]
 
     def append(
         self, dataset: str, version: str, source_uris: List[str]


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
We often see during nightly jobs to create new GLAD/integrated alerts tables a 500 response from the API on version creation, but the version often actually does get created. This then gives a 400 error on retry that the version already exists, and causes us to error out before finishing the sync job, even though the table was actually successfully uploaded.

## What is the new behavior?
On getting error from creating new version, check if version did successfully get created before returning an exception.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
