### PR TITLE
Only sync past day of subscriptions instead of default 2 days to avoid timeout

### DIFF
--- a/src/datapump/sync/rw_areas.py
+++ b/src/datapump/sync/rw_areas.py
@@ -3,6 +3,7 @@ import json
 import os
 import traceback
 from contextlib import contextmanager
+from datetime import datetime, timedelta
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 
 import requests
@@ -82,8 +83,10 @@ def get_pending_areas() -> List[Any]:
     LOGGER.info(f"Using token {token()} for {api_prefix()} API")
     headers: Dict[str, str] = {"Authorization": f"Bearer {token()}"}
 
-    # Area sync
-    sync_url: str = f"https://{api_prefix()}-api.globalforestwatch.org/v2/area/sync"
+    # For some reason we are the only place calling this RW API to sync
+    # new subscriptions with areas. See GTC-2987 to fix this workflow.
+    yesterday = (datetime.now() - timedelta(1)).strftime("%Y-%m-%d")
+    sync_url: str = f"https://{api_prefix()}-api.globalforestwatch.org/v2/area/sync?startDate={yesterday}"
     sync_resp = requests.post(sync_url, headers=headers)
 
     if sync_resp.status_code != 200:


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The call to /area/sync is timing out every night. Without date parameter, it defaults to syncing 2 days of subscriptions.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Only sync one day of subscriptions to reduce chance of timeout.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
