### PR TITLE
Get rid of error message after COG jobs successfully complete.

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -15,7 +15,7 @@ RUN pip install . -t python
 # to change the hash of the file and get TF to realize it needs to be
 # redeployed. Ticket for a better solution:
 # https://gfw.atlassian.net/browse/GTC-1250
-# change 8
+# change 9
 
 RUN yum install -y zip geos-devel
 

--- a/src/datapump/sync/sync.py
+++ b/src/datapump/sync/sync.py
@@ -224,7 +224,11 @@ class IntegratedAlertsSync(Sync):
                     band_count=1,
                     union_bands=True,
                     compute_stats=False,
-                    timeout_sec=21600,
+                    # This timeout is about 5-6 hours for the date_conf and intensity
+                    # raster jobs (run in series), and then another 6-7 hours for the
+                    # default and intensity COG jobs (run in parallel). The
+                    # generation of the default COG takes the longest.
+                    timeout_sec=13 * 3600,
                 ),
                 tile_cache_parameters=RasterTileCacheParameters(
                     max_zoom=14,


### PR DESCRIPTION
Get rid of error message after COG jobs successfully complete.

Even when the integrated alerts COG jobs successfully complete, there is a data-updates error message. It turns out this is because we didn't increase the integrated_alerts job timeout when we added the very long extra COG steps. The final cogify step completes, but a timeout error is still reported. So, I just added an extra 7 hours to the timeout for IntegratedAlertsSync job.
