### PR TITLE
Increase timeout for the unify_projection part of dist alert processing

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -15,7 +15,7 @@ RUN pip install . -t python
 # to change the hash of the file and get TF to realize it needs to be
 # redeployed. Ticket for a better solution:
 # https://gfw.atlassian.net/browse/GTC-1250
-# change 17
+# change 18
 
 RUN yum install -y zip geos-devel
 

--- a/src/datapump/sync/sync.py
+++ b/src/datapump/sync/sync.py
@@ -788,7 +788,9 @@ class DISTAlertsSync(Sync):
                 band_count=1,
                 compute_stats=False,
                 union_bands=True,
-                unify_projection=True
+                unify_projection=True,
+                # Sometimes this job runs over 2 hours, so increase timeout to 3 hours.
+                timeout_sec=3 * 3600
             ),
             content_date_range=ContentDateRange(
                 start_date="2020-12-31", end_date=str(date.today())


### PR DESCRIPTION
The initial ingestion job for dist alerts (which includes unify_projection) usually finishes in under 2 hours, but every few times, it goes over. And this then wedges all processing for that version (until deleted manually). So increase the timeout to 3 hours.

This is a hot fix, since there are a bunch of other outstanding hotfixes in master as well. Once this goes in, I will merge all the hotfixes back to develop.
