### PR TITLE
wait for cog creation to complete before setting version to latest

### DIFF
--- a/src/datapump/jobs/version_update.py
+++ b/src/datapump/jobs/version_update.py
@@ -75,21 +75,18 @@ class RasterVersionUpdateJob(Job):
         elif self.step == RasterVersionUpdateJobStep.creating_tile_cache:
             status = self._check_tile_cache_status()
             if status == JobStatus.complete:
-                self.step = RasterVersionUpdateJobStep.mark_latest
-                self._mark_latest()
+                if self.aux_tile_set_parameters:
+                    self.step = RasterVersionUpdateJobStep.creating_aux_assets
+                    for tile_set_params in self.aux_tile_set_parameters:
+                        self._create_aux_tile_set(tile_set_params)
+                else:
+                    self.step = RasterVersionUpdateJobStep.mark_latest
+                    self._mark_latest()
             elif status == JobStatus.failed:
                 self.status = JobStatus.failed
 
         elif self.step == RasterVersionUpdateJobStep.creating_aggregated_tile_set:
             status = self._check_aux_assets_status()
-            if status == JobStatus.complete:
-                self.step = RasterVersionUpdateJobStep.mark_latest
-                self._mark_latest()
-            elif status == JobStatus.failed:
-                self.status = JobStatus.failed
-
-        elif self.step == RasterVersionUpdateJobStep.mark_latest:
-            status = self._check_latest_status()
             if status == JobStatus.complete:
                 if self.aux_tile_set_parameters:
                     self.step = RasterVersionUpdateJobStep.creating_aux_assets
@@ -97,6 +94,13 @@ class RasterVersionUpdateJob(Job):
                         self._create_aux_tile_set(tile_set_params)
                 else:
                     self.status = JobStatus.complete
+            elif status == JobStatus.failed:
+                self.status = JobStatus.failed
+
+        elif self.step == RasterVersionUpdateJobStep.mark_latest:
+            status = self._check_latest_status()
+            if status == JobStatus.complete:
+                self.status = JobStatus.complete
             elif status == JobStatus.failed:
                 self.status = JobStatus.failed
 
@@ -110,14 +114,16 @@ class RasterVersionUpdateJob(Job):
                             self.status = JobStatus.failed
                             break
                 else:
-                    self.status = JobStatus.complete
+                    self.step = RasterVersionUpdateJobStep.mark_latest
+                    self._mark_latest()
             elif status == JobStatus.failed:
                 self.status = JobStatus.failed
 
         elif self.step == RasterVersionUpdateJobStep.creating_cog_assets:
             status = self._check_aux_assets_status()
             if status == JobStatus.complete:
-                self.status = JobStatus.complete
+                self.step = RasterVersionUpdateJobStep.mark_latest
+                self._mark_latest()
             elif status == JobStatus.failed:
                 self.status = JobStatus.failed
 


### PR DESCRIPTION
Right now we don't wait for COG creation to complete before setting version to latest. This causes tile service to fail as it tries to display an incomplete cog from the latest version.
This solution (not the only way) reorders the job step sequence from  **tile set --> tile cache | tile aggregation --> marking latest --> auxiliary asset creation (intensity) --> cog creation** to **tile set --> tile cache | tile aggregation --> auxiliary asset creation (intensity) --> cog creation --> marking latest