### PR TITLE
Use hash index for geostore integrated alerts table instead of btree

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -15,7 +15,7 @@ RUN pip install . -t python
 # to change the hash of the file and get TF to realize it needs to be
 # redeployed. Ticket for a better solution:
 # https://gfw.atlassian.net/browse/GTC-1250
-# change 21
+# change 22
 
 RUN yum install -y zip geos-devel
 

--- a/src/datapump/jobs/geotrellis.py
+++ b/src/datapump/jobs/geotrellis.py
@@ -569,6 +569,22 @@ class GeotrellisJob(Job):
             # a month the clustering won't even matter anymore.
             cluster = None  # Index(index_type="gist", column_names=["geom_wm"])
             indices.append(Index(index_type="gist", column_names=["geom"]))
+        elif (
+            self.table.analysis == Analysis.integrated_alerts
+            and analysis_agg == "daily_alerts"
+            and self.feature_type != "geostore"
+        ):
+            # this table is multi-use, so also create indices for individual alerts
+            glad_s2_cols = [
+                "umd_glad_sentinel2_alerts__confidence",
+                "umd_glad_sentinel2_alerts__date",
+            ]
+            wur_radd_cols = ["wur_radd_alerts__confidence", "wur_radd_alerts__date"]
+
+            indices += [
+                Index(index_type="btree", column_names=id_cols + glad_s2_cols),
+                Index(index_type="btree", column_names=id_cols + wur_radd_cols),
+            ]
 
         return indices, cluster
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
We create three multi-column btree indices. These often cause the DB instance to run out of space because they're so complex.

Issue Number: N/A


## What is the new behavior?
Replace all three with just one hash index on geostore__id. Tested in staging that this performs as well or better with the query used for the pie chart widget on Flagship.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
