### PR TITLE
 wait for cog creation to complete before setting version to latest (second version)

### DIFF
--- a/src/datapump/commands/version_update.py
+++ b/src/datapump/commands/version_update.py
@@ -55,6 +55,8 @@ class CogAssetParameters(StrictBaseModel):
     resampling: str = "mode"
     export_to_gee: bool = False
 
+
 class AuxTileSetParameters(RasterTileSetParameters):
     source_uri: None = None
     auxiliary_asset_pixel_meaning: Optional[str]
+    auxiliary_asset_version: str = None

--- a/src/datapump/jobs/version_update.py
+++ b/src/datapump/jobs/version_update.py
@@ -211,8 +211,12 @@ class RasterVersionUpdateJob(Job):
 
         # Looks up asset ID of the latest version raster tile set with auxiliary_asset_pixel_meaning
         if co.auxiliary_asset_pixel_meaning:
-            latest_version = client.get_latest_version(self.dataset)
-            assets = client.get_assets(self.dataset, latest_version)
+            auxiliary_asset_version = (
+                co.auxiliary_asset_version
+                if co.auxiliary_asset_version
+                else client.get_latest_version(self.dataset)
+            )
+            assets = client.get_assets(self.dataset, auxiliary_asset_version)
             for asset in assets:
                 if asset["asset_type"] == "Raster tile set":
                     creation_options = client.get_asset_creation_options(asset['asset_id'])

--- a/src/datapump/sync/sync.py
+++ b/src/datapump/sync/sync.py
@@ -814,7 +814,8 @@ class DISTAlertsSync(Sync):
                 calc="(B > 0) * 55",
                 grid="10/40000",
                 no_data=None,
-                auxiliary_asset_pixel_meaning = "default"
+                auxiliary_asset_pixel_meaning="default",
+                auxiliary_asset_version=latest_release
             )
         ]
         job.cog_asset_parameters = [


### PR DESCRIPTION
Right now we don't wait for COG creation to complete before setting version to latest. This causes tile service to fail as it tries to display an incomplete cog from the latest version.
This solution (not the only way) reorders the job step sequence from tile set --> tile cache | tile aggregation --> marking latest --> auxiliary asset creation (intensity) --> cog creation to tile set --> tile cache | tile aggregation --> auxiliary asset creation (intensity) --> cog creation --> marking latest

I was a bit on the fence abt having aux asset creation block marking latest for other (non-cog) scenarios but the only other place we use that is when creating date_conf for GLAD L alerts which we may also want to complete before marking latest (for Integrated Alerts use). But let me if see you any issues with this.
