### PR TITLE
GTC-3197 Stop making static tile cache for integrated alerts

### DIFF
--- a/src/datapump/sync/sync.py
+++ b/src/datapump/sync/sync.py
@@ -240,11 +240,6 @@ class IntegratedAlertsSync(Sync):
                     # generation of the default COG takes the longest.
                     timeout_sec=13 * 3600,
                 ),
-                tile_cache_parameters=RasterTileCacheParameters(
-                    max_zoom=14,
-                    resampling="med",
-                    symbology={"type": "date_conf_intensity_multi_8"},
-                ),
                 content_date_range=ContentDateRange(
                     start_date="2014-12-31", end_date=str(date.today())
                 ),


### PR DESCRIPTION
GTC-3197 Stop making static tile cache for integrated alerts

Flagship and Pro and any other users have now switched to titiler (see GTC-3197, FLAG-1233, GPV-4416), so we can stop generating the static tile cache for the nightly integrated alerts versions.  This can compensate for some of the extra CPU that the titiler server is using.

