### PR TITLE
Add lifecycle rules to remove old geotrellis/results (and logs)

### DIFF
--- a/terraform/lifecycle.tf
+++ b/terraform/lifecycle.tf
@@ -1,0 +1,35 @@
+resource "aws_s3_bucket_lifecycle_configuration" "expire_results" {
+  bucket = data.terraform_remote_state.core.outputs.pipelines_bucket
+
+  rule {
+    id = "expire-results"
+
+    filter {
+      prefix = "geotrellis/results/"
+    }
+
+    expiration {
+      days = 45
+    }
+
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "expire_logs" {
+  bucket = data.terraform_remote_state.core.outputs.pipelines_bucket
+
+  rule {
+    id = "expire-logs"
+
+    filter {
+      prefix = "geotrellis/logs/"
+    }
+
+    expiration {
+      days = 45
+    }
+
+    status = "Enabled"
+  }
+}


### PR DESCRIPTION
Add lifecycle rules to remove old s3://gfw-pipelines/geotrellis/results (and logs) folders

The s3://gfw-pipelines/geotrellis/results is a set of nightly results that is huge. It generates 250Gb per night now. I created a lifecycle rule by hand to delete them all up to about 90 days (which probably already deleted about 25 TB), and now want to make a terraform-controlled rule lowering that to 45 days.

s3://gfw-pipelines/geotrellis/logs is not as much disk space, but because of many Flagship EMR jobs per night, it had about 15000 folders. I similarly created a lifecycle rule by hand to delete them all up to about 90 days, and now want to make a terraform-controlled rule lowering that to 45 days.

I will delete the by-hand rules before this change goes into production.
