### PR TITLE
GTC-3357 Dist alert datapump changes for int/dist merge

### DIFF
--- a/src/datapump/jobs/version_update.py
+++ b/src/datapump/jobs/version_update.py
@@ -127,8 +127,8 @@ class RasterVersionUpdateJob(Job):
             if status == JobStatus.complete:
                 if self.cog_or_aux_asset_parameters:
                     self.step = RasterVersionUpdateJobStep.creating_cog_or_aux_assets
-                    for cog_asset_param in self.cog_or_aux_asset_parameters:
-                        if self._create_cog_or_aux_asset(cog_asset_param) == "":
+                    for cog_or_aux_asset_param in self.cog_or_aux_asset_parameters:
+                        if self._create_cog_or_aux_asset(cog_or_aux_asset_param) == "":
                             self.status = JobStatus.failed
                             break
                 else:

--- a/src/datapump/sync/sync.py
+++ b/src/datapump/sync/sync.py
@@ -892,7 +892,7 @@ class DISTAlertsSync(Sync):
                 source_uri=None,
                 pixel_meaning="date_conf",
                 data_type="uint16",
-                calc="B+2192",
+                calc="np.where(B > 0, B+2192, 0)",
                 grid="10/40000",
                 no_data=0,
                 auxiliary_asset_pixel_meaning="default",


### PR DESCRIPTION
GTC-3357 Dist alert datapump changes for int/dist merge

The main thing is adding a job that runs in parallel with the COG jobs to resample dist alerts raster to 10m resolution. This required making job.cog_asset_parameters be job.cog_or_aux_asset_parameters that can handle both COG and aux asset requests.

I also added a new aux_asset job to create a date_conf raster for dist alerts that has the right date basis so that OTF queries via the data API can correctly use the __date and __confidence fields. (OTF analysis on dist was requested by Anika and Sarah.)

I also added a bunch of comments on the sequence of steps for RasterVersionUpdateJob jobs.

