### PR TITLE
Send prefect webhook on Sunday for new intdist_version.

### DIFF
--- a/src/datapump/jobs/version_update.py
+++ b/src/datapump/jobs/version_update.py
@@ -406,7 +406,7 @@ class RasterVersionUpdateJob(Job):
             self.errors.append("Setting is_latest status failed")
             return JobStatus.failed
 
-    def get_prefect_webhook(self, dataset):
+    def _get_prefect_webhook(self, dataset):
         """Get prefect webhook URL for specified dataset from the secrets manager"""
         client = boto3.client("secretsmanager")
         response = client.get_secret_value(SecretId="prefect/webhook_urls")
@@ -414,7 +414,7 @@ class RasterVersionUpdateJob(Job):
 
     def _trigger_gnw_analysis(self):
         """Trigger GNW prefect pipeline based on new version of self.dataset."""
-        gnw_webhook_url = self.get_prefect_webhook(self.dataset)
+        gnw_webhook_url = self._get_prefect_webhook(self.dataset)
         resp = requests.post(
             gnw_webhook_url, json={"dataset": self.dataset, "version": self.version, "is_latest": True}
         )
@@ -423,6 +423,7 @@ class RasterVersionUpdateJob(Job):
                 f"Failed to trigger GNW notification for {self.dataset}/{self.version}: "
                 f"{resp.status_code} {resp.text}"
             )
+        slack_webhook("INFO", f"Running GNW pipeline for {self.dataset}/{self.version}")
 
     def _create_vrts(self):
         # Currently only creates VRTs with 2 components (2 elements in src_uris[])

--- a/src/datapump/jobs/version_update.py
+++ b/src/datapump/jobs/version_update.py
@@ -406,14 +406,15 @@ class RasterVersionUpdateJob(Job):
             self.errors.append("Setting is_latest status failed")
             return JobStatus.failed
 
-    def _get_slack_webhook(self, prefect_pipeline):
+    def get_prefect_webhook(self, dataset):
+        """Get prefect webhook URL for specified dataset from the secrets manager"""
         client = boto3.client("secretsmanager")
         response = client.get_secret_value(SecretId="prefect/webhook_urls")
-        return json.loads(response["SecretString"])[prefect_pipeline]
+        return json.loads(response["SecretString"])[dataset]
 
     def _trigger_gnw_analysis(self):
-        """Trigger GNW prefect pipeline with new version."""
-        gnw_webhook_url = self._get_slack_webhook(self.dataset)
+        """Trigger GNW prefect pipeline based on new version of self.dataset."""
+        gnw_webhook_url = self.get_prefect_webhook(self.dataset)
         resp = requests.post(
             gnw_webhook_url, json={"dataset": self.dataset, "version": self.version, "is_latest": True}
         )

--- a/src/datapump/sync/sync.py
+++ b/src/datapump/sync/sync.py
@@ -48,12 +48,12 @@ def delete_older_versions(dataset: str, cur_version: str, preservedays: int,
         client.delete_version(dataset, v)
 
 
-def is_first_sunday(vers: str) -> bool:
+def is_sunday(vers: str, first_sunday_of_month: bool = False) -> bool:
     try:
         dt = datetime.strptime(vers, 'v%Y%m%d')
         # .weekday() returns 0 for Monday, 1 for Tuesday, ..., and 6 for Sunday.
         # The first Sunday of any month must fall within the first 7 days of the month (1 <= day <= 7).
-        return dt.weekday() == 6 and 1 <= dt.day <= 7
+        return dt.weekday() == 6 and (not first_sunday_of_month or (1 <= dt.day <= 7))
     except ValueError:
         # Handle invalid date strings
         return False
@@ -1132,7 +1132,7 @@ class IntDistAlertsSync(Sync):
         # asset) on the first Sunday of the month (or the next version actually
         # created after the first Sunday).
         export_to_gee = False
-        if is_first_sunday(new_intdist_version):
+        if is_sunday(new_intdist_version, first_sunday_of_month=True):
             export_to_gee = True
         else:
             v = dec_version(new_intdist_version)
@@ -1141,13 +1141,27 @@ class IntDistAlertsSync(Sync):
             for i in range(7):
                 if v in versions:
                     break
-                if is_first_sunday(v):
+                if is_sunday(v, first_sunday_of_month=True):
                     export_to_gee = True
                     break
                 v = dec_version(v)
 
         if export_to_gee:
             slack_webhook("INFO", f"Creating overlap COG with block size 2048 at {self.DATASET_NAME}/{new_intdist_version} for GEE asset")
+
+        notify_gnw = False
+        if is_sunday(new_intdist_version):
+            notify_gnw = True
+        else:
+            for i in range(7):
+                if v in versions:
+                    break
+                if is_sunday(v):
+                    notify_gnw = True
+                    break
+                v = dec_version(v)
+        if notify_gnw:
+            slack_webhook("INFO", f"Runnning GNW pipeline for {self.DATASET_NAME}/{new_intdist_version}")
 
         job = RasterVersionUpdateJob(
             # Current week alerts tile set
@@ -1178,7 +1192,8 @@ class IntDistAlertsSync(Sync):
             content_date_range=ContentDateRange(
                 start_date="2014-12-31", end_date=str(date.today())
             ),
-            content_date_description=self.content_date_description
+            content_date_description=self.content_date_description,
+            notify_gnw=notify_gnw
         )
         job.aux_tile_set_parameters = [
             # Create the "intensity" tile set used to make the "intensity" COG.

--- a/src/datapump/sync/sync.py
+++ b/src/datapump/sync/sync.py
@@ -1153,6 +1153,9 @@ class IntDistAlertsSync(Sync):
         if is_sunday(new_intdist_version):
             notify_gnw = True
         else:
+            v = dec_version(new_intdist_version)
+            # Check if no version has been created since a Sunday occurred, in
+            # which case notify now.
             for i in range(7):
                 if v in versions:
                     break
@@ -1160,8 +1163,6 @@ class IntDistAlertsSync(Sync):
                     notify_gnw = True
                     break
                 v = dec_version(v)
-        if notify_gnw:
-            slack_webhook("INFO", f"Runnning GNW pipeline for {self.DATASET_NAME}/{new_intdist_version}")
 
         job = RasterVersionUpdateJob(
             # Current week alerts tile set

--- a/src/datapump/util/slack.py
+++ b/src/datapump/util/slack.py
@@ -3,40 +3,47 @@ import json
 import boto3
 import requests
 
-from ..globals import GLOBALS
+from ..globals import GLOBALS, LOGGER
 
 
 def slack_webhook(level, message):
-    if GLOBALS.env == "production":
-        channel: str = "data-updates"
-    elif GLOBALS.env == "staging":
-        channel = "data-updates-staging"
-    else:
-        return
-    app = "GFW SYNC - DATAPUMP - DATASET UPDATE"
+    # Sending a Slack message is never critical, so absorb any exceptions
+    # (e.g. secrets manager or network failures) rather than letting them
+    # propagate to the caller.
+    try:
+        if GLOBALS.env == "production":
+            channel: str = "data-updates"
+        elif GLOBALS.env == "staging":
+            channel = "data-updates-staging"
+        else:
+            return
+        app = "GFW SYNC - DATAPUMP - DATASET UPDATE"
 
-    if level.upper() == "WARNING":
-        color = "#E2AC37"
-    elif level.upper() == "ERROR" or level.upper() == "CRITICAL":
-        color = "#FF0000"
-    else:
-        color = "#36A64F"
+        if level.upper() == "WARNING":
+            color = "#E2AC37"
+        elif level.upper() == "ERROR" or level.upper() == "CRITICAL":
+            color = "#FF0000"
+        else:
+            color = "#36A64F"
 
-    attachment = {
-        "attachments": [
-            {
-                "fallback": "{} - {} - {}".format(app, level.upper(), message),
-                "color": color,
-                "title": app,
-                "fields": [
-                    {"title": level.upper(), "value": message, "short": False}
-                ],
-            }
-        ]
-    }
+        attachment = {
+            "attachments": [
+                {
+                    "fallback": "{} - {} - {}".format(app, level.upper(), message),
+                    "color": color,
+                    "title": app,
+                    "fields": [
+                        {"title": level.upper(), "value": message, "short": False}
+                    ],
+                }
+            ]
+        }
 
-    url = get_slack_webhook(channel)
-    return requests.post(url, json=attachment)
+        url = get_slack_webhook(channel)
+        return requests.post(url, json=attachment)
+    except Exception as e:
+        LOGGER.warning(f"Failed to send Slack message: {e}")
+        return None
 
 
 def get_slack_webhook(channel):


### PR DESCRIPTION
Send prefect webhook on Sunday when a new intdist_version is created (or the next day when a new version is created).

I have a corresponding PR for the zeno pipeline that handles the prefect webhook and runs the integrated_alerts_flow, in order to create a new version of the int-dist zarr and parquet.